### PR TITLE
修复制造工作位置取材并优化工作地点倍率与耗时显示

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -23,6 +23,7 @@
 #include "colony.h"
 #include "construction.h"
 #include "contents_change_handler.h"
+#include "crafting.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -1653,7 +1654,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         if( p ) {
             item_location to_craft = item_to_craft_at( *p, src_loc );
             if( to_craft && to_craft->is_craft() ) {
-                const inventory &inv = you.crafting_inventory( src_loc.raw(), PICKUP_RANGE, false );
+                const tripoint work_position = crafting_work_position( you, src_loc.raw() );
+                const inventory &inv = you.crafting_inventory( work_position, PICKUP_RANGE, true );
                 const recipe& r = to_craft->get_making();
                 std::vector<std::vector<item_comp>> item_comp_vector =
                     to_craft->get_continue_reqs().get_components();
@@ -3189,7 +3191,9 @@ static requirement_check_result generic_multi_activity_check_requirement(
             combined_spots.emplace_back( elem );
         }
         const int nearby_radius = act_id == ACT_MULTIPLE_CRAFT ? PICKUP_RANGE : PICKUP_RANGE - 1;
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, nearby_radius,
+        const tripoint_bub_ms nearby_center = act_id == ACT_MULTIPLE_CRAFT ?
+                tripoint_bub_ms( crafting_work_position( you, src_loc.raw() ) ) : src_loc;
+        for( const tripoint_bub_ms &elem : here.points_in_radius( nearby_center, nearby_radius,
                 nearby_radius ) ) {
             combined_spots.push_back( elem );
         }
@@ -3283,7 +3287,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                            reason == do_activity_reason::NEEDS_MINING;
         // is it even worth fetching anything if there isn't enough nearby?
         if( !are_requirements_nearby( tool_pickup ? loot_zone_spots : combined_spots, what_we_need, you,
-                                      act_id, tool_pickup, src_loc ) ) {
+                                      act_id, tool_pickup, nearby_center ) ) {
             if( act_id == ACT_MULTIPLE_CRAFT ) {
                 you.add_msg_player_or_npc( m_bad,
                                            _( "工作地点附近缺少继续制造所需的物品或工具，制作已停止。" ),
@@ -3318,7 +3322,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         local_src_set.push_back( here.bub_from_abs( elem ) );
                     }
                     std::vector<tripoint_bub_ms> candidates;
-                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc,
+                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( nearby_center,
                             nearby_radius, nearby_radius ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
                         if( !you.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -114,7 +114,7 @@ void craft_command::execute( bool only_cache_comps )
     }
 
     bool need_selections = true;
-    const tripoint origin = loc ? *loc : crafter->pos();
+    const tripoint origin = crafting_work_position( *crafter, loc );
     inventory map_inv;
     map_inv.form_from_map( origin, PICKUP_RANGE, crafter );
     const inventory &crafting_inv = crafter->crafting_inventory( origin, PICKUP_RANGE, true );
@@ -263,7 +263,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         bool no_prompt )
 {
     map &m = get_map();
-    const tripoint origin = loc ? *loc : crafter->pos();
+    const tripoint origin = crafting_work_position( *crafter, loc );
     for( const auto &it : item_selections ) {
         const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
         if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
@@ -437,7 +437,7 @@ item craft_command::create_in_progress_craft()
         return item();
     }
 
-    const tripoint origin = loc ? *loc : crafter->pos();
+    const tripoint origin = crafting_work_position( *crafter, loc );
     inventory map_inv;
     map_inv.form_from_map( origin, PICKUP_RANGE, crafter );
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -30,6 +30,7 @@
 #include "color.h"
 #include "craft_command.h"
 #include "crafting_gui.h"
+#include "creature_tracker.h"
 #include "debug.h"
 #include "enum_traits.h"
 #include "enums.h"
@@ -174,12 +175,76 @@ std::optional<tripoint> resolve_crafting_workplace(
     return best_marked ? best_marked : best_regular;
 }
 
+static float best_workbench_multiplier_near( map &here, const tripoint &loc )
+{
+    float best = 0.0f;
+    for( const tripoint &adj : here.points_in_radius( loc, 1 ) ) {
+        if( here.dangerous_field_at( adj ) ) {
+            continue;
+        }
+        best = std::max( best, workbench_multiplier_at( here, adj ) );
+    }
+    return best;
+}
+
+tripoint crafting_work_position( const Character &crafter,
+                                 const std::optional<tripoint> &workplace )
+{
+    // Players already have to stand next to a selected workplace.  Their real position is the
+    // authoritative origin for nearby materials, including when a vehicle workbench occupies an
+    // impassable tile.
+    if( !workplace || !crafter.is_npc() ) {
+        return crafter.pos();
+    }
+    if( crafter.posz() != workplace->z ) {
+        return crafter.pos();
+    }
+
+    map &here = get_map();
+    creature_tracker &creatures = get_creature_tracker();
+    std::vector<tripoint> candidates;
+    for( const tripoint &adj : here.points_in_radius( *workplace, 1 ) ) {
+        if( adj.z != workplace->z ) {
+            continue;
+        }
+        if( adj == crafter.pos() || ( here.passable( adj ) && !creatures.creature_at( adj ) ) ) {
+            candidates.push_back( adj );
+        }
+    }
+
+    // Mirror the existing NPC workbench pathing: prefer the best workbench reachable from a
+    // candidate tile, then preserve nearest-first ordering for equal workbench multipliers.
+    std::stable_sort( candidates.begin(), candidates.end(), [&]( const tripoint &lhs,
+    const tripoint & rhs ) {
+        return rl_dist( crafter.pos(), lhs ) < rl_dist( crafter.pos(), rhs );
+    } );
+    std::stable_sort( candidates.begin(), candidates.end(), [&]( const tripoint &lhs,
+    const tripoint & rhs ) {
+        return best_workbench_multiplier_near( here, lhs ) >
+               best_workbench_multiplier_near( here, rhs );
+    } );
+
+    const std::set<tripoint> &avoid = crafter.get_path_avoid();
+    for( const tripoint &candidate : candidates ) {
+        if( candidate == crafter.pos() ) {
+            return candidate;
+        }
+        if( !here.route( crafter.pos(), candidate, crafter.get_pathfinding_settings(), avoid ).empty() ) {
+            return candidate;
+        }
+    }
+
+    // Unreachable workplaces are rejected separately.  Falling back to the crafter keeps menu
+    // inventory checks rooted on a valid tile instead of reviving the impassable-workbench bug.
+    return crafter.pos();
+}
+
 static const inventory &crafting_inventory_at( Character &crafter,
         const std::optional<tripoint> &workplace )
 {
     const std::optional<tripoint> effective = resolve_crafting_workplace( crafter, workplace );
-    return effective ? crafter.crafting_inventory( *effective, PICKUP_RANGE, true ) :
-           crafter.crafting_inventory();
+    return crafter.crafting_inventory( crafting_work_position( crafter, effective ),
+                                       PICKUP_RANGE, true );
 }
 
 static bool has_safe_crafting_position( const tripoint &workplace )
@@ -2606,7 +2671,7 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
     const std::vector<comp_selection<tool_comp>> &cached_tool_selections =
                 craft.get_cached_tool_selections();
 
-    const tripoint origin = workplace ? *workplace : pos();
+    const tripoint origin = crafting_work_position( *this, workplace );
     inventory map_inv;
     map_inv.form_from_map( origin, PICKUP_RANGE, this );
 

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -33,4 +33,9 @@ void drop_or_handle( const item &newit, Character &p );
 // Marked crafting spots are preferred over ordinary workbenches.
 std::optional<tripoint> resolve_crafting_workplace(
     const Character &crafter, const std::optional<tripoint> &selected_workplace );
+// Return the tile the crafter actually uses as their working position for nearby resources.
+// Players always use their real position; remote NPCs predict the same adjacent work position
+// used by their workbench pathing.
+tripoint crafting_work_position( const Character &crafter,
+                                 const std::optional<tripoint> &workplace );
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -63,6 +63,7 @@ static const std::string flag_BLIND_EASY( "BLIND_EASY" );
 static const std::string flag_BLIND_HARD( "BLIND_HARD" );
 
 static const limb_score_id limb_score_manip( "manip" );
+static const string_id<struct furn_t> furn_f_fake_bench_hands( "f_fake_bench_hands" );
 static const string_id<struct furn_t> furn_f_ground_crafting_spot( "f_ground_crafting_spot" );
 static const field_type_str_id fd_crafting_spot( "fd_crafting_spot" );
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
@@ -308,12 +309,36 @@ static float crafting_light_at( const Character &crafter, const recipe &rec,
             workplace ? *workplace : tripoint_zero );
 }
 
+static float workbench_base_multiplier_at( const std::optional<tripoint> &workplace )
+{
+    if( !workplace ) {
+        const furn_t &hands = furn_f_fake_bench_hands.obj();
+        return hands.workbench ? hands.workbench->multiplier : 1.0f;
+    }
+
+    map &here = get_map();
+    if( const std::optional<vpart_reference> vp = here.veh_at( *workplace ).part_with_feature(
+                "WORKBENCH", true ) ) {
+        if( const std::optional<vpslot_workbench> &wb = vp->part().info().get_workbench_info() ) {
+            return wb->multiplier;
+        }
+    }
+    if( here.has_furn( *workplace ) && here.furn( *workplace ).obj().workbench ) {
+        return here.furn( *workplace ).obj().workbench->multiplier;
+    }
+
+    // A marked point without a real workbench is worked on as a ground craft.
+    const furn_t &ground = furn_f_ground_crafting_spot.obj();
+    return ground.workbench ? ground.workbench->multiplier : 0.7f;
+}
+
 static float crafting_speed_at( const Character &crafter, const recipe &rec,
                                 const std::optional<tripoint> &workplace )
 {
     const float result = crafter.morale_crafting_speed_multiplier( rec ) *
                          crafting_light_at( crafter, rec, workplace ) *
-                         crafter.get_limb_score( limb_score_manip );
+                         crafter.get_limb_score( limb_score_manip ) *
+                         workbench_base_multiplier_at( workplace );
     return std::max( result, 0.0f );
 }
 
@@ -356,27 +381,6 @@ static bool is_marked_crafting_spot( const tripoint &location )
     map &here = get_map();
     return here.furn( location ) == furn_f_ground_crafting_spot ||
            here.get_field( location, fd_crafting_spot ) != nullptr;
-}
-
-static std::string workplace_description_at( const tripoint &location )
-{
-    map &here = get_map();
-    if( const std::optional<vpart_reference> vp = here.veh_at( location ).part_with_feature(
-                "WORKBENCH", true ) ) {
-        if( const std::optional<vpslot_workbench> &wb = vp->part().info().get_workbench_info() ) {
-            return string_format( _( "载具工作台，倍率 %.2f" ), wb->multiplier );
-        }
-        return _( "载具工作台" );
-    }
-    if( here.has_furn( location ) && here.furn( location ).obj().workbench ) {
-        const furn_t &furniture = here.furn( location ).obj();
-        const std::string type = here.furn( location ) == furn_f_ground_crafting_spot ?
-                                 _( "地面制造点" ) :
-                                 is_marked_crafting_spot( location ) ? _( "标记工作台" ) :
-                                 _( "家具工作台" );
-        return string_format( _( "%s，倍率 %.2f" ), type, furniture.workbench->multiplier );
-    }
-    return _( "指定地点" );
 }
 
 static bool has_adjacent_work_position( const tripoint &loc )
@@ -503,27 +507,9 @@ static std::vector<crafting_workplace> collect_crafting_workplaces(
 static std::string workplace_detail_text( const crafting_workplace &workplace,
         const Character &crafter )
 {
-    std::vector<std::string> parts;
-    if( !workplace.location ) {
-        const std::optional<tripoint> effective = resolve_crafting_workplace(
-                    crafter, std::nullopt );
-        if( effective ) {
-            parts.emplace_back( string_format( _( "自动采用：%s，%s" ),
-                                               workplace_name_at( *effective ),
-                                               workplace_description_at( *effective ) ) );
-        } else {
-            parts.emplace_back( _( "附近无工作台，将手持或在地面制造" ) );
-        }
-    } else {
-        parts.emplace_back( workplace.type );
-        if( !workplace.detail.empty() ) {
-            parts.emplace_back( workplace.detail );
-        }
-    }
-    if( !workplace.selectable ) {
-        parts.emplace_back( _( "附近没有安全站位" ) );
-    }
-    return enumerate_as_string( parts, enumeration_conjunction::none );
+    const std::optional<tripoint> effective = workplace.location ? workplace.location :
+            resolve_crafting_workplace( crafter, std::nullopt );
+    return string_format( "%.2f", workbench_base_multiplier_at( effective ) );
 }
 
 static std::string workplace_relative_text( const crafting_workplace &workplace,
@@ -2892,12 +2878,12 @@ static bool choose_crafting_settings( const std::vector<Character *> &crafting_g
             }
             menu.set_selected( crafter_selected_row );
         } else if( page == settings_page::workplace ) {
-            menu.set_column_weights( { 20, 8, 28, 12, 32 } );
+            menu.set_column_weights( { 24, 8, 40, 16, 12 } );
             const std::string crafter_name = selected_crafter.is_avatar() ? _( "你" ) :
                                              selected_crafter.get_name();
             menu.set_header( { _( "工作地点" ), _( "可制作" ), _( "缺少" ),
-                               string_format( _( "距%s" ), crafter_name ), _( "说明" ) } );
-            menu.set_footer( _( "Tab／Shift+Tab切换分页，回车选择，Esc返回。蓝色名称表示已标记工作台。" ) );
+                               string_format( _( "距%s" ), crafter_name ), _( "倍率" ) } );
+            menu.set_footer( _( "自动选择优先最佳工作台，无工作台时手持1.00，地面0.70。蓝色名称为标记工作台。" ) );
 
             const npc *selected_npc = selected_crafter.as_npc();
             const std::optional<tripoint> queue_location = selected_npc ?

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -297,8 +297,8 @@ static crafting_menu_defaults last_crafting_settings;
 static const inventory &crafting_inventory_at( Character &crafter,
         const std::optional<tripoint> &workplace )
 {
-    return workplace ? crafter.crafting_inventory( *workplace, PICKUP_RANGE, true ) :
-           crafter.crafting_inventory();
+    return crafter.crafting_inventory( crafting_work_position( crafter, workplace ),
+                                       PICKUP_RANGE, true );
 }
 
 static float crafting_light_at( const Character &crafter, const recipe &rec,
@@ -546,11 +546,11 @@ static std::string selected_workplace_text( const Character &crafter,
                               crafter_name, workplace_distance_text( crafter, *selected_location ) );
     }
     if( effective_location ) {
-        return string_format( _( "自动选择（%s，距%s%s）" ),
+        return string_format( _( "自动选择，%s，距%s%s" ),
                               workplace_name_at( *effective_location ), crafter_name,
                               workplace_distance_text( crafter, *effective_location ) );
     }
-    return _( "自动选择（手持或地面制造）" );
+    return _( "自动选择" );
 }
 
 static bool craft_is_assigned_to( const item &craft, const npc &who )
@@ -2892,7 +2892,7 @@ static bool choose_crafting_settings( const std::vector<Character *> &crafting_g
             }
             menu.set_selected( crafter_selected_row );
         } else if( page == settings_page::workplace ) {
-            menu.set_column_weights( { 24, 10, 10, 14, 42 } );
+            menu.set_column_weights( { 20, 8, 28, 12, 32 } );
             const std::string crafter_name = selected_crafter.is_avatar() ? _( "你" ) :
                                              selected_crafter.get_name();
             menu.set_header( { _( "工作地点" ), _( "可制作" ), _( "缺少" ),


### PR DESCRIPTION
## 概述

本 PR 修复制造系统的工作位置取材逻辑，并优化工作地点界面的倍率显示与制作时间估算。核心原则：**工作地点决定在哪里工作，工作位置决定从哪里取材。**

## 问题背景

原实现把所选工作台格直接作为 `crafting_inventory` 和组件消耗的搜索原点，而载具工作台格可能不可通行。启用清晰路径扫描后，玩家明明站在桌边，却看不到周围任何材料和工具，出现整页配方失去材料的严重体验问题。同时，制造菜单的速度提示和完成耗时估算未计入工作台基础倍率，玩家无法预判切换手持/地面/工作台对耗时的实际影响。

## 改动机制

### 1. 新增 `crafting_work_position()` 统一取材中心（src/crafting.h、src/crafting.cpp）

- **玩家**永远以角色当前实际站立格作为工作位置——无论自动选中家具工作台还是不可站立的载具工作台，附近资源都从玩家真实位置计算；
- **NPC**保留远程指挥能力：尚未走到工作台时，按现有 NPC 工作台寻路规则预测最终相邻站位（候选格需可通行且无生物占据），按"工作台倍率优先、同倍率距离优先"排序并用寻路检查实际可达性；NPC 到达后当前站位自然成为同一算法的首选结果；
- 以下路径全部统一使用工作位置作为取材中心，不再出现菜单判断、实际消耗与后续制作使用不同搜索中心的情况：
  - 配方可用性与组件选择（`crafting_inventory_at`，crafting.cpp 与 crafting_gui.cpp 两处）；
  - 开始制作时的材料消耗（`craft_command::execute` 等 craft_command.cpp 三处原点）；
  - 液体容器检查（`continue_prompt_liquids`）；
  - 持续工具分段耗能（`Character::craft_consume_tools`）；
  - NPC 制造清单的继续制造检查（activity_item_handling.cpp 中 ACT_MULTIPLE_CRAFT 分支，同时保留 `clear_path=true` 的隔墙不可取材约束）与补料搜索、材料放置范围（`nearby_center`）。

### 2. 工作地点分页 UI 重构（src/crafting_gui.cpp）

- 删除冗长的"说明"文字列，最后一栏改为**倍率**，直接显示该工作地点的真实基础倍率：
  - 无工作台（手持，取 `f_fake_bench_hands`）：`1.00`
  - 显式地面制造点（`f_ground_crafting_spot`）：`0.70`
  - 家具工作台 / 载具工作台：读取家具或部件 JSON 定义的实际倍率（如 `1.10`）
- 新增 `workbench_base_multiplier_at()`，制造菜单的**制造速度提示**与**完成耗时估算**现在乘以当前有效工作地点的基础倍率，切换工作方式时预计耗时会同步变化；
- 列宽从 `{20,8,28,12,32}` 调整为 `{24,8,40,16,12}`，最大空间留给"缺少"栏；
- 页脚简化为自动选择规则说明（自动选择优先最佳工作台，无工作台时手持 1.00、地面 0.70）。

### 已知边界

游戏运行时还会对过重、过大的制造中物品施加工作台承载惩罚；菜单在组件选中、制造中物品生成前无法得知该动态惩罚，故显示的是按基础倍率修正后的预计时间。普通尺寸制作与实际一致，大型工程开始后仍可能进一步变慢。

## 改动范围

| 文件 | 内容 |
|---|---|
| `src/crafting.h` | 声明 `crafting_work_position()` |
| `src/crafting.cpp` | 实现 NPC 站位预测算法；统一取材中心；工具耗能原点 |
| `src/crafting_gui.cpp` | 菜单取材中心、倍率列与页脚、速度/耗时估算计入倍率 |
| `src/craft_command.cpp` | 制作命令三处取材原点统一 |
| `src/activity_item_handling.cpp` | NPC 续制检查与补料/放置范围以预测站位为中心 |

不涉及 JSON 数据、配方、翻译资源变更；所有界面文本沿用仓库中文源串直书惯例，数字使用阿拉伯数字格式。Android 代码不受影响。

## 适用对象与使用方法

适用于所有制造场景，无需新解锁内容：

- 玩家在载具工作台旁正常取材制作，不再需要手动挪动材料；
- 通过制造设置给 NPC 指定远处工作台后，菜单即可正确预判可制作状态与耗时，NPC 会走到预测站位继续制作；
- 工作地点分页可直接对比各候选点的倍率与缺少项，配合"缺少"列加宽快速排查缺料原因。

## 测试

- **Windows & Android Test 运行编号 263**（head SHA `4e666ba0db37d49dd6ff9ba82fed4e56d79c03b0`）：Windows Tiles x64 MSVC 与 Android arm64 双 job 全部通过。
  运行链接：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32621425315
- 游戏内回归已按 TEST_PLAN 完成：载具工作台相邻取材、以玩家为中心取材、隔墙不可取材、NPC 远程站位预测一致性、NPC 补料恢复、持续工具耗能不中断、倍率显示 1.00/0.70/1.10、完成耗时随倍率变化等场景均符合预期。

## 提交清单

| 提交 | 内容 |
|---|---|
| `5168e1f1` | 修复制造工作位置取材并优化工作地点界面 |
| `4e666ba0` | 工作地点倍率与真实制作时间修复 |
