### PR TITLE
整合商会印刷机任务、坠落伤害接口与旅行的意义更新

### DIFF
--- a/data/json/fall_damage_eocs.json
+++ b/data/json/fall_damage_eocs.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FALL_DAMAGE_PARKOUR_EXPERT",
+    "eoc_type": "FALL_DAMAGE",
+    "condition": {
+      "compare_int": [ { "u_val": "proficiency", "proficiency_id": "prof_parkour", "format": "percent" }, ">=", { "const": 100 } ]
+    },
+    "effect": [
+      {
+        "arithmetic": [
+          { "u_val": "var", "var_name": "fall_damage_multiplier", "type": "general", "context": "fall_damage" },
+          "*=",
+          { "const": 50 }
+        ]
+      },
+      {
+        "arithmetic": [
+          { "u_val": "var", "var_name": "fall_damage_multiplier", "type": "general", "context": "fall_damage" },
+          "/=",
+          { "const": 100 }
+        ]
+      }
+    ]
+  }
+]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1269,6 +1269,10 @@
     "type": "json_flag"
   },
   {
+    "id": "SPATIAL_BARRIER",
+    "type": "json_flag"
+  },
+  {
     "id": "PORTAL_PROOF",
     "type": "json_flag"
   },

--- a/data/json/itemgroups/SUS/printing.json
+++ b/data/json/itemgroups/SUS/printing.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "item_group",
+    "id": "SUS_commercial_printing_equipment",
+    "//": "Heavy commercial printing equipment that can plausibly appear in dedicated office production, civic document, or warehouse office spaces.",
+    "subtype": "collection",
+    "items": [ { "item": "commercial_screen_printing_press", "prob": 100 } ]
+  }
+]

--- a/data/json/items/generic/free_merchant_infrastructure.json
+++ b/data/json/items/generic/free_merchant_infrastructure.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "GENERIC",
+    "id": "commercial_screen_printing_press",
+    "name": {
+      "str": "商用平板丝网印刷机"
+    },
+    "description": "一台带真空平板和微调定位机构的商用丝网印刷设备，机身上固定着网框，刮板和一套基本配件，适合在纸张和薄片材料上批量套印复杂图案，整机非常沉重，想把它带走最好准备一辆能装重货的车。",
+    "category": "tools",
+    "weight": "85 kg",
+    "volume": "250 L",
+    "longest_side": "120 cm",
+    "price": 250000,
+    "price_postapoc": 5000,
+    "to_hit": -10,
+    "bashing": 12,
+    "material": [
+      "steel",
+      "aluminum"
+    ],
+    "symbol": ";",
+    "color": "light_gray",
+    "looks_like": "fog_machine"
+  }
+]

--- a/data/json/mapgen/town_hall.json
+++ b/data/json/mapgen/town_hall.json
@@ -70,7 +70,10 @@
       "e": { "item": "SUS_fridge_breakroom", "chance": 55, "repeat": [ 2, 3 ] },
       "O": { "item": "SUS_oven", "chance": 100 },
       "u": [ { "item": "SUS_coffee_cupboard", "chance": 50 }, { "item": "dining", "chance": 30 } ],
-      "R": { "item": "office_supplies", "chance": 50, "repeat": [ 1, 2 ] },
+      "R": [
+        { "item": "office_supplies", "chance": 50, "repeat": [ 1, 2 ] },
+        { "item": "SUS_commercial_printing_equipment", "chance": 2 }
+      ],
       "I": { "item": "SUS_office_filing_cabinet", "chance": 80 }
     },
     "item": { "/": { "item": "american_flag" }, "[": { "item": "american_flag" } },

--- a/data/json/mapgen/warehouse.json
+++ b/data/json/mapgen/warehouse.json
@@ -68,7 +68,8 @@
       "toilets": { "4": {  } },
       "place_items": [
         { "item": "cannedfood", "x": [ 2, 2 ], "y": [ 19, 20 ], "chance": 20 },
-        { "item": "softdrugs", "x": [ 2, 3 ], "y": [ 16, 16 ], "chance": 30 }
+        { "item": "softdrugs", "x": [ 2, 3 ], "y": [ 16, 16 ], "chance": 30 },
+        { "item": "SUS_commercial_printing_equipment", "x": 4, "y": 20, "chance": 3 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
       "place_vehicles": [

--- a/data/json/mapgen_palettes/office.json
+++ b/data/json/mapgen_palettes/office.json
@@ -91,7 +91,10 @@
         { "item": "fridgesnacks", "chance": 70, "repeat": [ 1, 10 ] }
       ],
       "o": { "item": "oven", "chance": 70 },
-      "r": [ { "item": "office_supplies", "chance": 65, "repeat": [ 1, 10 ] } ],
+      "r": [
+        { "item": "office_supplies", "chance": 65, "repeat": [ 1, 10 ] },
+        { "item": "SUS_commercial_printing_equipment", "chance": 1 }
+      ],
       "y": { "item": "cleaning", "chance": 60, "repeat": [ 1, 2 ] },
       "Y": { "item": "jackets", "chance": 90, "repeat": [ 3, 8 ] },
       "a": { "item": "trash", "chance": 70, "repeat": [ 2, 5 ] },

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/NPC_Smokes.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/NPC_Smokes.json
@@ -10,7 +10,7 @@
     "attitude": 0,
     "mission": 3,
     "chat": "TALK_FREE_MERCHANTS_MERCHANT",
-    "mission_offered": "MISSION_FREE_MERCHANTS_EVAC_1",
+    "mission_offered": [ "MISSION_FREE_MERCHANTS_EVAC_1", "MISSION_FREE_MERCHANTS_PRINTING_PRESS" ],
     "faction": "free_merchants"
   },
   {
@@ -25,7 +25,14 @@
     "//3": "Most of his dialogue goes in 'free_merchant_shopkeep_dialogue.json'. Dialogue that just does worldbuilding goes into 'free_merchant_shopkeep_dialogue_fluff.json'.",
     "bonus_str": 4,
     "bonus_dex": 2,
-    "shopkeeper_item_group": [ { "group": "FREE_MERCHANTS_Shop", "rigid": true } ],
+    "shopkeeper_item_group": [
+      { "group": "FREE_MERCHANTS_Shop", "rigid": true },
+      {
+        "group": "FREE_MERCHANTS_Shop_Currency_Press",
+        "rigid": true,
+        "restock_repeat_global": "free_merchants_press_count"
+      }
+    ],
     "shopkeeper_consumption_rates": "smokes_shop_rates",
     "worn_override": "NC_FREE_MERCHANTS_MERCHANT_worn",
     "weapon_override": "NC_FREE_MERCHANTS_MERCHANT_carried",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_currency_press.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_currency_press.json
@@ -1,0 +1,121 @@
+[
+  {
+    "type": "item_group",
+    "id": "FREE_MERCHANTS_Shop_Currency_Press",
+    "subtype": "collection",
+    "items": [
+      { "item": "FMCNote", "count": 1000 },
+      { "item": "money_strap_FMCNote", "count": 40 }
+    ]
+  },
+  {
+    "id": "MISSION_FREE_MERCHANTS_PRINTING_PRESS",
+    "type": "mission_definition",
+    "name": {
+      "str": "扩大票据生产"
+    },
+    "description": "为自由商人找回一台商用平板丝网印刷机，让他们能够稳定批量加工商会币。",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 4,
+    "value": 0,
+    "item": "commercial_screen_printing_press",
+    "count": 1,
+    "origins": [
+      "ORIGIN_SECONDARY"
+    ],
+    "followup": "MISSION_FREE_MERCHANTS_PRINTING_PRESS_EXTRA",
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "loffice_tower_9b",
+        "z": 4,
+        "reveal_radius": 1,
+        "random": true,
+        "create_if_necessary": true,
+        "search_range": 240
+      },
+      "update_mapgen": {
+        "place_item": [
+          {
+            "item": "commercial_screen_printing_press",
+            "x": 10,
+            "y": 10
+          }
+        ]
+      }
+    },
+    "end": {
+      "effect": [
+        {
+          "arithmetic": [
+            {
+              "global_val": "var",
+              "var_name": "free_merchants_press_count"
+            },
+            "=",
+            {
+              "const": 1
+            }
+          ]
+        },
+        { "u_spawn_item": "FMCNote", "count": 100 }
+      ],
+      "opinion": { "trust": 2, "value": 2 }
+    },
+    "dialogue": {
+      "describe": "我们缺一套能稳定批量处理票据的设备。",
+      "offer": "我们的商会币不是从白纸做出来的，我们会在旧的大额纸币上重新印承兑说明和图案，再交给财务负责人签字。现在最大的问题是加工速度。有人提过一栋大型办公楼的高层以前有内部图文部门，那里可能还留着一台商用平板丝网印刷机。那东西很重，不过如果你能把它完整带回来，我们就能把商会币的周转量提上去。",
+      "accepted": "我把那栋楼的位置标给你，机器应该在最高的办公层，去内部办公区的工作台和设备桌附近找。",
+      "rejected": "没关系，这东西确实不好搬。",
+      "advice": "别想着背回来，准备一辆能装重货的车，到了顶层办公区以后重点看看工作台和设备桌。",
+      "inquire": "印刷机找到了吗，应该就在顶层办公区的工作台附近。",
+      "success": "很好，这就是我们要的。机器还能用，我们刚试着跑了一批。这100张你拿着，算是第一批票据的纪念。以后每轮我们能多准备大约5000商会币。你要是以后还碰到同型号的机器，也可以继续带给我。",
+      "success_lie": "这么大的机器可没法藏在口袋里。",
+      "failure": "那栋楼不值得拿命去换，活着回来就行。"
+    }
+  },
+  {
+    "id": "MISSION_FREE_MERCHANTS_PRINTING_PRESS_EXTRA",
+    "type": "mission_definition",
+    "name": {
+      "str": "扩建票据工位"
+    },
+    "description": "再为自由商人运回一台商用平板丝网印刷机，每增加一台设备都会继续提高商会币的周期供应量。",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 3,
+    "value": 0,
+    "item": "commercial_screen_printing_press",
+    "count": 1,
+    "origins": [
+      "ORIGIN_SECONDARY"
+    ],
+    "followup": "MISSION_FREE_MERCHANTS_PRINTING_PRESS_EXTRA",
+    "end": {
+      "effect": [
+        {
+          "arithmetic": [
+            {
+              "global_val": "var",
+              "var_name": "free_merchants_press_count"
+            },
+            "+=",
+            {
+              "const": 1
+            }
+          ]
+        },
+        { "u_spawn_item": "FMCNote", "count": 50 }
+      ]
+    },
+    "dialogue": {
+      "describe": "如果你还碰到同型号的机器，我们一直收。",
+      "offer": "现有工位已经能稳定工作了，不过这种设备越多，票据周转就越快。以后你在其他办公场所再找到同型号的机器，可以继续带回来。每多一台，我们每轮就能再多准备大约5000商会币。",
+      "accepted": "不用专门为它冒险，碰到了再带回来就行。",
+      "rejected": "没关系，这本来就是长期的事。",
+      "advice": "这种机器很重，先把运输工具准备好。",
+      "inquire": "又找到一台印刷机了吗。",
+      "success": "很好，我们会给它腾出一个新工位。这50张算我们的收购价。下一轮补货开始，这台机器也会算进票据产能里。",
+      "success_lie": "机器就在附近的话，我自己也看得见。",
+      "failure": "不用勉强，我们现有的工位还能继续运转。"
+    }
+  }
+]

--- a/data/mods/旅行的意义/地图派系/公路酒馆/06_武器与特调.json
+++ b/data/mods/旅行的意义/地图派系/公路酒馆/06_武器与特调.json
@@ -576,7 +576,7 @@
       "科比·布莱恩特"
     ],
     "desc": [
-      "特殊调酒带来的爆发式身体强化，让你的力量，敏捷与行动速度显著提高。"
+      "特殊调酒带来的爆发式身体强化，让你的力量，敏捷与行动速度显著提高，同时让你在坠落时毫发无伤。"
     ],
     "rating": "good",
     "max_intensity": 1,
@@ -600,7 +600,7 @@
     "name": {
       "str": "科比·布莱恩特"
     },
-    "description": "一杯纪念科比·布莱恩特的特殊调酒，名字来自那位永远追求极限的篮球传奇。喝下它，你会在一小时内获得惊人的力量，敏捷与行动速度；它不会减免坠落伤害。\n“Man！what can i say”",
+    "description": "一杯纪念科比·布莱恩特的特殊调酒，名字来自那位永远追求极限的篮球传奇。喝下它，你会在一小时内获得惊人的力量，敏捷与行动速度，并且完全免疫坠落伤害。\n“Man！what can i say”",
     "weight": "250 g",
     "color": "magenta",
     "addiction_type": "alcohol",
@@ -648,33 +648,13 @@
     "name": {
       "str": "无下限术式闪避"
     },
-    "description": "五条悟特调生效期间使用的隐藏防御特性：让攻击者极难命中，并快速从摔倒状态恢复。",
+    "description": "旧版本无下限术式使用的隐藏兼容特性，现在不再提供任何防御能力。",
     "points": 0,
     "valid": false,
     "player_display": false,
     "purifiable": false,
-    "flags": [
-      "HARDTOHIT",
-      "DOWNED_RECOVERY",
-      "FEATHER_FALL"
-    ],
-    "enchantments": [
-      {
-        "condition": "ALWAYS",
-        "values": [
-          {
-            "value": "BONUS_DODGE",
-            "add": 10000
-          }
-        ],
-        "skills": [
-          {
-            "value": "dodge",
-            "add": 100
-          }
-        ]
-      }
-    ]
+    "flags": [],
+    "enchantments": []
   },
   {
     "type": "effect_type",
@@ -683,38 +663,13 @@
       "无下限术式"
     ],
     "desc": [
-      "无下限术式般的力量隔绝了袭来的伤害。"
+      "无下限术式让一切试图直接接触你的物理攻击停在最后一段距离之外，注视，精神影响，环境危害与直接作用仍然能够穿透。"
     ],
     "rating": "good",
     "max_intensity": 1,
     "max_duration": "60 seconds",
+    "flags": [ "SPATIAL_BARRIER" ],
     "show_in_info": true
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_TRAVEL_GOJO_INFINITY_SYNC",
-    "recurrence": "1 second",
-    "global": true,
-    "run_for_npcs": false,
-    "condition": {
-      "u_has_effect": "travel_afterlife_boost_gojo"
-    },
-    "effect": [
-      {
-        "u_add_trait": "DEBUG_NODMG"
-      },
-      {
-        "u_add_trait": "TRAVEL_GOJO_INFINITY_DODGE"
-      }
-    ],
-    "false_effect": [
-      {
-        "u_lose_trait": "DEBUG_NODMG"
-      },
-      {
-        "u_lose_trait": "TRAVEL_GOJO_INFINITY_DODGE"
-      }
-    ]
   },
   {
     "type": "COMESTIBLE",
@@ -722,13 +677,13 @@
     "name": {
       "str": "五条悟"
     },
-    "description": "一杯颜色近乎透明的特殊调酒，入口清冽，随后会在身体周围形成一种难以理解的疏离感，仿佛任何危险都永远差着最后一点距离。名字来自一位自称最强的咒术师，这一分钟足够让人明白他为什么敢这么说。\n“我的学生们还在看着呢，再让我耍会帅吧”",
+    "description": "一杯颜色近乎透明的特殊调酒，入口清冽，随后会在身体周围形成一种难以理解的疏离感，仿佛任何试图直接触及你的东西都永远差着最后一点距离。名字来自一位自称最强的咒术师，这一分钟足够让人明白他为什么敢这么说。\n“我的学生们还在看着呢，再让我耍会帅吧”",
     "weight": "250 g",
     "color": "light_blue",
     "addiction_type": "alcohol",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "你喝下了五条悟。袭来的危险仿佛在触及你之前停住了。",
+      "activation_message": "你喝下了五条悟，袭来的攻击仿佛在触及你之前停住了。",
       "effects": [
         {
           "id": "travel_afterlife_boost_gojo",

--- a/data/mods/旅行的意义/地图派系/公路酒馆/07_坠落保护.json
+++ b/data/mods/旅行的意义/地图派系/公路酒馆/07_坠落保护.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TRAVEL_AFTERLIFE_KOBE_FALL_IMMUNITY",
+    "eoc_type": "FALL_DAMAGE",
+    "condition": { "u_has_effect": "travel_afterlife_boost_kobe" },
+    "effect": {
+      "arithmetic": [
+        { "u_val": "var", "var_name": "fall_damage_multiplier", "type": "general", "context": "fall_damage" },
+        "=",
+        { "const": 0 }
+      ]
+    }
+  }
+]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -13,7 +13,15 @@ An effect_on_condition is an object allowing the combination of dialog condition
 | `global`| bool | If this is true, this recurring eoc will be run on the player and every npc from a global queue.  Deactivate conditions will work based on the avatar. If it is false the avatar and every character will have their own copy and their own deactivated list. Defaults to false.
 | `run_for_npcs`| bool | Can only be true if global is true. If false the eoc will only be run against the avatar. If true the eoc will be run against the avatar and all npcs.  Defaults to false.
 | `EOC_TYPE`| string | The effect_on_condition is automatically invoked once on scenario start.
- Can be any of:ACTIVATION, RECURRING, SCENARIO_SPECIFIC, AVATAR_DEATH, NPC_DEATH, OM_MOVE, PREVENT_DEATH. It defaults to ACTIVATION unless `recurrence` is provided in which case it defaults to RECURRING.  If it is SCENARIO_SPECIFIC it is automatically invoked once on scenario start. If it is PREVENT_DEATH whenever the current avatar dies it will be run with the avatar as u, if after it the player is no longer dead they will not die, if there are multiple they all be run until the player is not dead. If it is AVATAR_DEATH whenever the current avatar dies it will be run with the avatar as u and the killer as npc. NPC_DEATH eocs can only be assigned to run on the death of an npc, in which case u will be the dying npc and npc will be the killer. OM_MOVE EOCs trigger when the player moves overmap tiles.
+ Can be any of:ACTIVATION, RECURRING, SCENARIO_SPECIFIC, AVATAR_DEATH, NPC_DEATH, OM_MOVE, PREVENT_DEATH, FALL_DAMAGE. It defaults to ACTIVATION unless `recurrence` is provided in which case it defaults to RECURRING.  If it is SCENARIO_SPECIFIC it is automatically invoked once on scenario start. If it is PREVENT_DEATH whenever the current avatar dies it will be run with the avatar as u, if after it the player is no longer dead they will not die, if there are multiple they all be run until the player is not dead. If it is AVATAR_DEATH whenever the current avatar dies it will be run with the avatar as u and the killer as npc. NPC_DEATH eocs can only be assigned to run on the death of an npc, in which case u will be the dying npc and npc will be the killer. OM_MOVE EOCs trigger when the player moves overmap tiles. FALL_DAMAGE EOCs run immediately before landing impact damage is applied, with the impacted character as u.
+
+### Fall damage hook
+
+`FALL_DAMAGE` EOCs can change the temporary player variable `fall_damage_multiplier` with `type: "general"` and `context: "fall_damage"`.  The value uses permille, so 1000 is normal damage, 500 is half damage, 2000 is double damage, and 0 prevents the landing damage entirely.  Multiple EOCs should normally multiply this value rather than replace it so independent modifiers compose cleanly.
+
+The temporary player variable `fall_impact_force` with the same type and context contains the effective landing force before the EOC modifiers are applied.  It is intended for conditions that only affect sufficiently hard falls.  Both temporary variables are removed after the hook finishes.
+
+For example, an effect, mutation, item state, proficiency, or mod can define a `FALL_DAMAGE` EOC and multiply `fall_damage_multiplier` when its own condition is true.  No C++ changes are needed for additional modifiers.
 
 ## Examples:
 ```JSON

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11200,6 +11200,12 @@ float Character::fall_damage_mod() const
 // force is maximum damage to hp before scaling
 int Character::impact( const int force, const tripoint &p )
 {
+    // Debug invincibility, incorporeality and spatial barriers stop impact side effects before armor and terrain handling.
+    if( has_trait( trait_DEBUG_NODMG ) || has_effect( effect_incorporeal ) ||
+        blocks_physical_contact() ) {
+        return 0;
+    }
+
     // Falls over ~30m are fatal more often than not
     // But that would be quite a lot considering 21 z-levels in game
     // so let's assume 1 z-level is comparable to 30 force
@@ -11300,14 +11306,34 @@ int Character::impact( const int force, const tripoint &p )
         }
     }
 
+    float fall_damage_multiplier = 1.0f;
+    if( !slam ) {
+        static const std::string multiplier_var =
+            "npctalk_var_general_fall_damage_fall_damage_multiplier";
+        static const std::string impact_force_var =
+            "npctalk_var_general_fall_damage_fall_impact_force";
+
+        set_value( multiplier_var, "1000" );
+        set_value( impact_force_var, std::to_string( effective_force ) );
+        effect_on_conditions::process_fall_damage( *this );
+
+        const std::string modified_multiplier = get_value( multiplier_var );
+        if( !modified_multiplier.empty() ) {
+            fall_damage_multiplier = std::max( 0.0f,
+                                               std::atoi( modified_multiplier.c_str() ) / 1000.0f );
+        }
+        remove_value( multiplier_var );
+        remove_value( impact_force_var );
+    }
+
     int total_dealt = 0;
-    if( mod * effective_force >= 5 ) {
+    if( mod * effective_force * fall_damage_multiplier >= 5 ) {
         for( const bodypart_id &bp : get_all_body_parts( get_body_part_flags::only_main ) ) {
             const int bash = effective_force * rng( 60, 100 ) / 100;
             damage_instance di;
-            di.add_damage( damage_type::BASH, bash, 0, armor_eff, mod );
+            di.add_damage( damage_type::BASH, bash, 0, armor_eff, mod * fall_damage_multiplier );
             // No good way to land on sharp stuff, so here modifier == 1.0f
-            di.add_damage( damage_type::CUT, cut, 0, armor_eff, 1.0f );
+            di.add_damage( damage_type::CUT, cut, 0, armor_eff, fall_damage_multiplier );
             total_dealt += deal_damage( nullptr, bp, di ).total_damage();
         }
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1040,6 +1040,15 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         // Total miss
         return;
     }
+    if( blocks_physical_contact() && !magic ) {
+        attack.dealt_dam = dealt_damage_instance();
+        attack.hit_critter = this;
+        attack.missed_by = 0.0;
+        if( print_messages ) {
+            add_msg_if_player( m_good, _( "投射物在触及你之前停住了。" ) );
+        }
+        return;
+    }
     // If carrying a rider, there is a chance the hits may hit rider instead.
     if( has_effect( effect_ridden ) ) {
         monster *mons = as_monster();
@@ -1636,6 +1645,12 @@ bool Creature::has_effect_with_flag( const flag_id &flag ) const
         // effect::has_flag currently delegates to effect_type::has_flag
         return elem.first->has_flag( flag );
     } );
+}
+
+bool Creature::blocks_physical_contact() const
+{
+    static const flag_id flag_SPATIAL_BARRIER( "SPATIAL_BARRIER" );
+    return has_effect_with_flag( flag_SPATIAL_BARRIER );
 }
 
 std::vector<effect> Creature::get_effects_with_flag( const flag_id &flag ) const
@@ -2861,6 +2876,10 @@ void Creature::knock_back_from( const tripoint &p )
 {
     if( p == pos() ) {
         return; // No effect
+    }
+    if( blocks_physical_contact() ) {
+        add_msg_if_player( m_good, _( "推动你的力量在触及你之前停住了。" ) );
+        return;
     }
     if( is_hallucination() ) {
         die( nullptr );

--- a/src/creature.h
+++ b/src/creature.h
@@ -411,6 +411,9 @@ class Creature : public viewer
          */
         double ranged_target_size() const;
 
+        /** True when an active effect prevents physical objects and contact attacks from reaching this creature. */
+        bool blocks_physical_contact() const;
+
         // handles blocking of damage instance. mutates &dam
         virtual bool block_hit( Creature *source, bodypart_id &bp_hit,
                                 damage_instance &dam ) = 0;

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -24,6 +24,7 @@ namespace io
         case eoc_type::NPC_DEATH: return "NPC_DEATH";
         case eoc_type::OM_MOVE: return "OM_MOVE";
         case eoc_type::PREVENT_DEATH: return "PREVENT_DEATH";
+        case eoc_type::FALL_DAMAGE: return "FALL_DAMAGE";
         case eoc_type::NUM_EOC_TYPES: break;
         }
         cata_fatal( "Invalid eoc_type" );
@@ -421,6 +422,16 @@ void effect_on_conditions::om_move()
     dialogue d( get_talker_for( player_character ), nullptr );
     for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
         if( eoc.type == eoc_type::OM_MOVE ) {
+            eoc.activate( d );
+        }
+    }
+}
+
+void effect_on_conditions::process_fall_damage( Character &you )
+{
+    dialogue d( get_talker_for( you ), nullptr );
+    for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
+        if( eoc.type == eoc_type::FALL_DAMAGE ) {
             eoc.activate( d );
         }
     }

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -22,6 +22,7 @@ enum eoc_type {
     NPC_DEATH,
     OM_MOVE,
     PREVENT_DEATH,
+    FALL_DAMAGE,
     NUM_EOC_TYPES
 };
 struct effect_on_condition {
@@ -83,6 +84,8 @@ void clear( Character &you );
 /** write out all queued eocs and inactive eocs to a file for testing */
 void write_eocs_to_file( Character &you );
 void write_global_eocs_to_file();
+/** Run all FALL_DAMAGE EOCs with the impacted character as u. */
+void process_fall_damage( Character &you );
 /** Run all prevent death eocs */
 void prevent_death();
 /** Run all avatar death eocs */

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -572,7 +572,7 @@ void ExplosionProcess::project_shrapnel(const tripoint position)
 
 
     auto critter = c_t.creature_at(position);
-    if (critter && !critter->is_dead_state()) {
+    if (critter && !critter->is_dead_state() && !critter->blocks_physical_contact()) {
         int damage_taken = 0;
         // 变通 const auto bps = critter->get_all_body_parts(true);
         const auto bps = critter->get_all_body_parts();
@@ -653,7 +653,10 @@ void ExplosionProcess::blast_tile(const tripoint position, const int rl_distance
     {
         Creature* critter = get_creature_tracker().creature_at(position);
 
-        if (critter != nullptr && !mobs_blasted.count(critter)) {
+        if (critter != nullptr && critter->blocks_physical_contact()) {
+            critter->add_msg_if_player( m_good, _( "爆炸冲击在触及你之前停住了。" ) );
+            mobs_blasted[critter] = 0;
+        } else if (critter != nullptr && !mobs_blasted.count(critter)) {
             const int blast_damage = blast_power * critter_blast_percentage(critter, blast_radius,
                 rl_distance);
             const auto shockwave_dmg = damage_instance::physical(blast_damage, 0, 0, 0.4f);
@@ -705,7 +708,7 @@ void ExplosionProcess::blast_tile(const tripoint position, const int rl_distance
         Creature* critter = get_creature_tracker().creature_at(position);
         avatar* player_ptr = dynamic_cast<avatar*>(critter);
 
-        if (critter != nullptr && !flung_set.count(critter)) {
+        if (critter != nullptr && !critter->blocks_physical_contact() && !flung_set.count(critter)) {
             const int push_strength = (blast_radius - rl_distance) * blast_power;
             const float move_power = ExplosionConstants::MOB_FLING_FACTOR * push_strength;
 

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -544,6 +544,13 @@ bool melee_actor::call( monster &z ) const
         }
     }
 
+    const bool contact_attack = damage_max_instance.total_damage() > 0 || !effects.empty() ||
+                                throw_strength > 0;
+    if( contact_attack && target->blocks_physical_contact() ) {
+        target->add_msg_if_player( m_good, _( "%s 的攻击在触及你之前停住了。" ), mon_name );
+        return true;
+    }
+
     // Dodge check
 
     const int acc = accuracy >= 0 ? accuracy : z.type->melee_skill;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -610,6 +610,16 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         return false;
     }
 
+    if( t.blocks_physical_contact() ) {
+        t.add_msg_if_player( m_good, _( "%s 的攻击在触及你之前停住了。" ), disp_name() );
+        const int total_stam = get_total_melee_stamina_cost();
+        mod_stamina( std::min( -50, total_stam ) );
+        const float weary_mult = exertion_adjusted_move_multiplier( EXTRA_EXERCISE );
+        mod_moves( -move_cost * ( 1 / weary_mult ) );
+        martial_arts_data->ma_onattack_effects( *this );
+        return true;
+    }
+
     if( is_avatar() && move_cost > 1000 && calendar::turn > melee_warning_turn ) {
         const std::string &action = query_popup()
                                     .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2941,6 +2941,10 @@ bool mattack::grab( monster *z )
     }
 
     z->moves -= 80;
+    if( target->blocks_physical_contact() ) {
+        target->add_msg_if_player( m_good, _( "%s 的抓取在触及你之前停住了。" ), z->disp_name() );
+        return true;
+    }
 
     const game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
     if( dodge_check( z, target ) ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2052,6 +2052,11 @@ bool monster::melee_attack(Creature& target, float accuracy)
         return false;
     }
 
+    if( target.blocks_physical_contact() ) {
+        target.add_msg_if_player( m_good, _( "%s 的攻击在触及你之前停住了。" ), disp_name() );
+        return true;
+    }
+
     int hitspread = target.deal_melee_attack(this, melee::melee_hit_range(accuracy));
     if (type->melee_dice == 0) {
         // We don't hit, so just return

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -35,6 +35,7 @@
 #include "flag.h"
 #include "game.h"
 #include "game_constants.h"
+#include "global_vars.h"
 #include "game_inventory.h"
 #include "item.h"
 #include "item_group.h"
@@ -2349,17 +2350,26 @@ void npc::shop_restock()
     for( const shopkeeper_item_group &ig : myclass->get_shopkeeper_items() ) {
         if( ig.can_restock( *this ) ) {
             if( ig.rigid ) {
-                rigid_groups.emplace_back( ig.id );
+                int repeat = 1;
+                if( !ig.restock_repeat_global.empty() ) {
+                    const std::string raw_repeat = get_globals().get_global_value(
+                                                       "npctalk_var_" + ig.restock_repeat_global );
+                    repeat = raw_repeat.empty() ? 0 : std::max( 0, std::atoi( raw_repeat.c_str() ) );
+                }
+                for( int i = 0; i < repeat; ++i ) {
+                    rigid_groups.emplace_back( ig.id );
+                }
             } else {
                 value_groups.emplace_back( ig.id );
             }
         }
     }
 
+    const float merchant_spawn_rate = get_option<float>( "MERCHANT_ITEM_SPAWNRATE" );
     std::list<item> ret;
-    int shop_value = 75000;
+    int shop_value = static_cast<int>( 75000 * merchant_spawn_rate );
     if( my_fac ) {
-        shop_value = my_fac->wealth * 0.0075;
+        shop_value = static_cast<int>( my_fac->wealth * 0.0075 * merchant_spawn_rate );
         if( !my_fac->currency.is_empty() ) {
             item my_currency( my_fac->currency );
             if( !my_currency.is_null() ) {
@@ -2372,17 +2382,29 @@ void npc::shop_restock()
         }
     }
 
-    // First, populate trade goods using rigid groups.
-    // Rigid groups are always processed a single time, regardless of the shopkeeper's inventory size or desired total value of goods.
-    for( const item_group_id &rg : rigid_groups ) {
+    // First, populate trade goods using rigid groups.  The dedicated merchant spawn rate applies to
+    // fixed groups as well as value-budget groups, independently of map item spawn rate.
+    const auto add_rigid_group = [&]( const item_group_id &rg, float keep_chance ) {
         item_group::ItemList rigid_items = item_group::items_from( rg, calendar::turn );
         if( !rigid_items.empty() ) {
             for( item &tmpit : rigid_items ) {
-                if( !tmpit.is_null() ) {
+                if( !tmpit.is_null() &&
+                    ( keep_chance >= 1.0f || rng_float( 0.0, 1.0 ) < keep_chance ) ) {
                     tmpit.set_owner( *this );
                     ret.push_back( tmpit );
                 }
             }
+        }
+    };
+
+    const int full_restock_runs = static_cast<int>( std::floor( merchant_spawn_rate ) );
+    const float partial_restock_rate = merchant_spawn_rate - full_restock_runs;
+    for( const item_group_id &rg : rigid_groups ) {
+        for( int run = 0; run < full_restock_runs; ++run ) {
+            add_rigid_group( rg, 1.0f );
+        }
+        if( partial_restock_rate > 0.0f ) {
+            add_rigid_group( rg, partial_restock_rate );
         }
     }
 
@@ -2400,14 +2422,6 @@ void npc::shop_restock()
                 count += 1;
                 last_item = count > 10 && one_in( 100 );
             }
-        }
-
-        // This removes some items according to item spawn scaling factor
-        const float spawn_rate = get_option<float>( "ITEM_SPAWNRATE" );
-        if( spawn_rate < 1 ) {
-            ret.remove_if( [spawn_rate]( auto & ) {
-                return !( rng_float( 0, 1 ) < spawn_rate );
-            } );
         }
     }
 

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -261,6 +261,7 @@ void shopkeeper_item_group::deserialize( const JsonObject &jo )
     optional( jo, false, "trust", trust, 0 );
     optional( jo, false, "strict", strict, false );
     optional( jo, false, "rigid", rigid, false );
+    optional( jo, false, "restock_repeat_global", restock_repeat_global );
     optional( jo, false, "refusal", refusal );
     if( jo.has_member( "condition" ) ) {
         read_condition<dialogue>( jo, "condition", condition, false );

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -54,8 +54,13 @@ struct shopkeeper_item_group {
     std::string refusal;
     std::function<bool( const dialogue & )> condition;
 
-    // Rigid shopkeeper groups will be processed a single time. Default groups are not rigid, and will be processed until the shopkeeper has no more room or remaining value to populate goods with.
+    // Rigid shopkeeper groups are processed independently of the shop value budget.  They run once by default,
+    // and can optionally repeat according to a global dialogue variable.
     bool rigid = false;
+
+    // Optional basename of a dialogue global variable.  Rigid groups are queued this many times when restocking.
+    // This lets world state and infrastructure upgrades scale fixed shop inventories without hard-coded NPC special cases.
+    std::string restock_repeat_global;
 
     shopkeeper_item_group() = default;
     shopkeeper_item_group( const std::string &id, int trust, bool strict, bool rigid = false ) :

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3206,13 +3206,21 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
     if( container_name.empty() ) {
         if( new_item.count_by_charges() ) {
             new_item.mod_charges( count - 1 );
-            d.actor( false )->i_add_or_drop( new_item );
+            if( Character *recipient = d.actor( false )->get_character() ) {
+                recipient->i_add( new_item, true, nullptr, nullptr, true, false, true );
+            } else {
+                d.actor( false )->i_add_or_drop( new_item );
+            }
         } else {
             for( int i_cnt = 0; i_cnt < count; i_cnt++ ) {
                 if( !new_item.ammo_default().is_null() ) {
                     new_item.ammo_set( new_item.ammo_default() );
                 }
-                d.actor( false )->i_add_or_drop( new_item );
+                if( Character *recipient = d.actor( false )->get_character() ) {
+                    recipient->i_add( new_item, true, nullptr, nullptr, true, false, true );
+                } else {
+                    d.actor( false )->i_add_or_drop( new_item );
+                }
             }
         }
         if( d.has_beta && !d.actor( true )->disp_name().empty() ) {
@@ -3230,7 +3238,11 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
         new_item.mod_charges( count - 1 );
         container.put_in( new_item,
                           item_pocket::pocket_type::CONTAINER );
-        d.actor( false )->i_add_or_drop( container );
+        if( Character *recipient = d.actor( false )->get_character() ) {
+            recipient->i_add( container, true, nullptr, nullptr, true, false, true );
+        } else {
+            d.actor( false )->i_add_or_drop( container );
+        }
         if( d.has_beta && !d.actor( true )->disp_name().empty() ) {
             //~ %1%s is the NPC name, %2$s is an item
             popup( _( "%1$s gives you a %2$s." ), d.actor( true )->disp_name(), container.tname() );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2660,6 +2660,11 @@ void options_manager::add_options_world_default()
          0.01, 10.0, 1.0, 0.01
        );
 
+    add( "MERCHANT_ITEM_SPAWNRATE", "world_default", to_translation( "商人物资生成倍率" ),
+         to_translation( "调整NPC商人每次补货时生成的商品数量，不影响地图和其他世界物资生成。数值高于一会增加补货量，低于一会减少补货量。" ),
+         0.01, 10.0, 1.0, 0.01
+       );
+
     add( "NPC_SPAWNTIME", "world_default", to_translation( "Random NPC spawn time" ),
          to_translation( "Baseline average number of days between random NPC spawns.  Average duration goes up with the number of NPCs already spawned.  A higher number means fewer NPCs.  Set to 0 days to disable random NPCs." ),
          0.0, 100.0, 4.0, 0.01

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1064,6 +1064,11 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             }
 
             time_stunned = time_duration::from_turns( ( rng( 0, dam ) > 10 ) + ( rng( 0, dam ) > 40 ) );
+            if( critter->blocks_physical_contact() ) {
+                time_stunned = 0_turns;
+                dam = 0;
+                critter->add_msg_if_player( m_good, _( "车辆的撞击在触及你之前停住了。" ) );
+            }
             if( time_stunned > 0_turns ) {
                 critter->add_effect( effect_stunned, time_stunned );
             }
@@ -1087,8 +1092,9 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
 
             // Don't fling if vertical - critter got smashed into the ground
             if( !vert_coll ) {
-                if( std::fabs( vel2_a ) > 10.0f ||
-                    std::fabs( e * mass * vel1_a ) > std::fabs( mass2 * ( 10.0f - vel2_a ) ) ) {
+                if( !critter->blocks_physical_contact() &&
+                    ( std::fabs( vel2_a ) > 10.0f ||
+                      std::fabs( e * mass * vel1_a ) > std::fabs( mass2 * ( 10.0f - vel2_a ) ) ) ) {
                     const units::angle angle = rng_float( -60_degrees, 60_degrees );
                     // Also handle the weird case when we don't have enough force
                     // but still have to push (in such case compare momentum)


### PR DESCRIPTION
## 概述

本 PR 从 main 基线（`4fe58e0c` 优化高空高速飞行载具的重复绘制 #1174）整合商会印刷机 v6 全部内容：斯莫克印刷机任务线、FALL_DAMAGE 坠落伤害 EOC 接口、商人物资生成倍率、五条悟无下限物理屏障与 NPC 奖励装袋修复。分支单提交 `247ad905`，共 28 个文件（+398/-87）。

## 核心新增功能

### 一、商会印刷机任务线
- 斯莫克（free_merchants_merchant）任务列表新增「扩大票据生产」，完成后可反复接取「扩建票据工位」。
- 首次交付奖励 100 商会币并提升信任（trust +2、value +2）；追加交付每台奖励 50 商会币。
- 单台产能：每补货周期刷新 FREE_MERCHANTS_Shop_Currency_Press 物资组（1000 张散装 FMCNote + 40 张整刀 money_strap_FMCNote），通过新增的 `restock_repeat_global` 机制按全局变量 free_merchants_press_count 的台数重复刷新，多台叠加。

### 二、FALL_DAMAGE 垃落伤害 EOC 接口
- 新增 eoc_type `FALL_DAMAGE`：角色落地撞击结算前以受击角色为 u 运行全部该类 EOC。
- 提供临时变量 fall_damage_multiplier（千分比，1000=正常，0=完全免疫）与 fall_impact_force（本次冲击强度），结算后自动删除，不污染存档。模组无需改 C++ 即可修改坠落伤害。
- 内置内容：跑酷专家（prof_parkour 完整掌握）坠落伤害减半；旅行的意义·科比布莱恩特特调生效期间坠落伤害为 0。
- 边界：仅作用于非 slam 落地路径，撞墙/撞车/被击飞等 slam 不受倍率影响，与原版 fall_damage_mod 边界一致。

### 三、五条悟无下限术式重做
- 删除旧实现（每秒同步 EOC 授予 DEBUG_NODMG 与 BONUS_DODGE 10000/闪避技能 +100），TRAVEL_GOJO_INFINITY_DODGE 特性保留但不再提供任何能力。
- 新增 json_flag `SPATIAL_BARRIER` 与 Creature::blocks_physical_contact()：效果携带该旗标时视为物理接触屏障。
- 屏障拦截范围：玩家与怪物近战、melee_actor 强击与击飞、抓取、投射物（带 magic 标记的直接法术刻意绕过）、爆炸冲击与击飞、车辆撞击（不掉血不眩晕不击飞）、坠落撞击（Character::impact 直接返回零）。
- 不拦截：燃烧之眼式凝视、精神影响、毒气烟雾、辐射、温度、中毒感染等非物理接触危害。

### 四、商人物资生成倍率
- 世界默认选项新增 MERCHANT_ITEM_SPAWNRATE（0.01–10.0，默认 1.0）：独立调整商人每次补货的商品数量，不影响地图物资生成；地图物资倍率调低时商店不再被连带砍量。
- 补货预算（75000 或派系财富换算值）与固定物资组都按该倍率缩放，高于 1 时固定组按整数倍完整多次刷新并有零头概率补充。

### 五、NPC 奖励自动装袋
- 对话直接给予玩家的物品改为优先尝试装入物品栏（i_add ignore_pkt_settings=true，服从真实口袋容积），无法容纳才落到脚下；斯莫克的 100/50 商会币奖励因此优先进入可用口袋。

## 获取方式

- **任务接取**：避难中心自由商人斯莫克处接取「扩大票据生产」。
- **印刷机获取**：任务会把目标标到一栋大型办公楼 z=4 最高办公层并在工作区桌面附近保底生成一台商用平板丝网印刷机（重 85kg，250L，需载具运输）；此外市政厅 R 位（2%）、仓库 place_items（3%）、办公楼调色板 r 位（1%）可通过 SUS_commercial_printing_equipment 物资组自然生成。
- **贴图适配**：印刷机 looks_like 指向 fog_machine，在 MSX++UnDeadPeopleEdition（不死人）图块包下复用现成物品贴图。

## 改动范围

- **C++（14 个文件）**：character.cpp（impact 无敌/虚体/屏障提前返回 + FALL_DAMAGE 钩子）、effect_on_condition.h/cpp（FALL_DAMAGE 类型与 process_fall_damage）、creature.h/cpp（blocks_physical_contact、投射物与击退拦截）、monster.cpp、mattack_actors.cpp、melee.cpp、monattack.cpp（近战/强击/抓取）、explosion.cpp（爆炸三处）、vehicle_move.cpp（车辆撞击两处）、npctalk.cpp（receive_item 装袋）、npc.cpp（shop_restock 倍率与重复刷新）、npc_class.h/cpp（restock_repeat_global 字段）、options.cpp（新世界选项）。
- **JSON/数据（12 个文件）**：fall_damage_eocs.json（新）、flags.json（SPATIAL_BARRIER）、itemgroups/SUS/printing.json（新）、items/generic/free_merchant_infrastructure.json（新）、npcs/Smokes/free_merchant_currency_press.json（新，任务定义+商店组）、NPC_Smokes.json、mapgen/town_hall.json、mapgen/warehouse.json、mapgen_palettes/office.json、旅行的意义 mod 06_武器与特调.json（科比/五条悟文案与机制修正）与 07_坠落保护.json（新）。
- **文档**：doc/EFFECT_ON_CONDITION.md 新增 FALL_DAMAGE 类型说明与 Fall damage hook 章节。

## 测试验证

- Windows & Android Test 运行编号 273 成功通过：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32718656249 （head `247ad905`）
- 本地 MSVC 编译与游戏实测（任务流程、坠落接口、屏障行为、产能刷新、贴图显示）已由提交者确认无误。

## 相关提交

- 功能分支单提交：`247ad905` 整合商会印刷机坠落接口与无下限物理屏障（基于 main `4fe58e0c`）