### PR TITLE
功能：家具和小型载具支持跨层拖拽

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11265,7 +11265,7 @@ int game::grabbed_furn_move_time( const tripoint &dp )
         return 0;
     }
 
-    tripoint fdest = fpos + tripoint( dp.xy(), 0 ); // intended destination of furniture.
+    tripoint fdest = fpos + dp; // intended destination of furniture.
 
     const bool canmove = can_move_furniture( fdest, dp );
     const furn_t &furntype = m.furn( fpos ).obj();
@@ -11334,20 +11334,12 @@ bool game::grabbed_furn_move( const tripoint &dp )
         return false;
     }
 
-    int ramp_offset = 0;
-    // Furniture could be on a ramp at different time than player so adjust for that.
-    if( m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fpos + tripoint( dp.xy(), 0 ) ) ) {
-        ramp_offset = 1;
-    } else if( m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fpos + tripoint( dp.xy(), 0 ) ) ) {
-        ramp_offset = -1;
-    }
-
     const bool pushing_furniture = dp.xy() ==  u.grab_point.xy();
     const bool pulling_furniture = dp.xy() == -u.grab_point.xy();
     const bool shifting_furniture = !pushing_furniture && !pulling_furniture;
 
-    // Intended destination of furniture.
-    const tripoint fdest = fpos + tripoint( dp.xy(), ramp_offset );
+    // Intended destination of furniture, including a possible z-level change.
+    const tripoint fdest = fpos + dp;
 
     // Unfortunately, game::is_empty fails for tiles we're standing on,
     // which will forbid pulling, so:
@@ -11487,8 +11479,6 @@ bool game::grabbed_furn_move( const tripoint &dp )
         return true;
     }
 
-    u.grab_point.z += ramp_offset;
-
     if( shifting_furniture ) {
         // We didn't move
         tripoint d_sum = u.grab_point + dp;
@@ -11512,7 +11502,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
     return false;
 }
 
-bool game::grabbed_move( const tripoint &dp, const bool via_ramp )
+bool game::grabbed_move( const tripoint &dp, const bool via_ramp, bool stairs_move )
 {
     if( u.get_grab_type() == object_type::NONE ) {
         return false;
@@ -11520,7 +11510,7 @@ bool game::grabbed_move( const tripoint &dp, const bool via_ramp )
 
     // vehicle: pulling, pushing, or moving around the grabbed object.
     if( u.get_grab_type() == object_type::VEHICLE ) {
-        return grabbed_veh_move( dp );
+        return grabbed_veh_move_helper( dp, via_ramp, stairs_move );
     }
 
     if( u.get_grab_type() == object_type::FURNITURE ) {
@@ -12161,12 +12151,30 @@ void game::vertical_move( int movez, bool force, bool peeking, bool check_traps 
         return;
     }
 
+    const object_type grabbed_type = u.get_grab_type();
+    std::optional<tripoint_abs_ms> grabbed_abs_pos;
     if( force ) {
-        // Let go of a grabbed cart.
         u.grab( object_type::NONE );
     } else if( u.grab_point != tripoint_zero ) {
-        add_msg( m_info, _( "You can't drag things up and down stairs." ) );
-        return;
+        if( climbing || can_swim_vertically ) {
+            add_msg( m_info, _( "这里不适合拖着东西跨层移动。" ) );
+            return;
+        }
+
+        const tripoint grabbed_pos = u.pos() + u.grab_point;
+        bool found_grabbed_object = false;
+        if( grabbed_type == object_type::FURNITURE ) {
+            found_grabbed_object = here.has_furn( grabbed_pos );
+        } else if( grabbed_type == object_type::VEHICLE ) {
+            found_grabbed_object = static_cast<bool>( here.veh_at( grabbed_pos ) );
+        }
+
+        if( !found_grabbed_object ) {
+            add_msg( m_info, _( "找不到原先抓住的物体，你松开了手。" ) );
+            u.grab( object_type::NONE );
+        } else {
+            grabbed_abs_pos = here.getglobal( grabbed_pos );
+        }
     }
 
     // TODO: Use u.posz() instead of m.abs_sub
@@ -12351,6 +12359,34 @@ void game::vertical_move( int movez, bool force, bool peeking, bool check_traps 
     // Now that we know the player's destination position, we can move their mount as well
     if( u.is_mounted() ) {
         u.mounted_creature->setpos( u.pos() );
+    }
+
+    if( grabbed_abs_pos.has_value() ) {
+        const tripoint grabbed_pos = here.getlocal( *grabbed_abs_pos );
+        bool found_grabbed_object = false;
+        if( here.inbounds( grabbed_pos ) ) {
+            if( grabbed_type == object_type::FURNITURE ) {
+                found_grabbed_object = here.has_furn( grabbed_pos );
+            } else if( grabbed_type == object_type::VEHICLE ) {
+                found_grabbed_object = static_cast<bool>( here.veh_at( grabbed_pos ) );
+            }
+        }
+
+        if( !found_grabbed_object ) {
+            add_msg( m_info, _( "跨层后找不到原先抓住的物体，你松开了手。" ) );
+            u.grab( object_type::NONE );
+        } else {
+            u.grab_point = grabbed_pos - u.pos();
+            const std::optional<tripoint> dir = choose_direction(
+                        _( "选择把拖拽物放在楼梯另一端的哪个方向。" ) );
+            if( !dir ) {
+                u.grab( object_type::NONE );
+            } else {
+                const tripoint target = u.pos() + tripoint( dir->xy(), 0 );
+                const tripoint dp = target - grabbed_pos;
+                grabbed_move( dp, false, true );
+            }
+        }
     }
 
     // This ugly check is here because of stair teleport bullshit

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11239,6 +11239,7 @@ bool game::phasing_move( const tripoint &dest_loc, const bool via_ramp )
 bool game::can_move_furniture( tripoint fdest, const tripoint &dp )
 {
     const bool pulling_furniture = dp.xy() == -u.grab_point.xy();
+    const bool cross_z_move = dp.z != 0;
     const bool has_floor = m.has_floor( fdest );
     creature_tracker &creatures = get_creature_tracker();
     bool is_ramp_or_road = m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fdest ) ||
@@ -11248,7 +11249,7 @@ bool game::can_move_furniture( tripoint fdest, const tripoint &dp )
             creatures.creature_at<npc>( fdest ) == nullptr &&
             creatures.creature_at<monster>( fdest ) == nullptr &&
             ( !pulling_furniture || is_empty( u.pos() + dp ) ) &&
-            ( !has_floor || m.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ||
+            ( cross_z_move || !has_floor || m.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ||
               is_ramp_or_road ) &&
             !m.has_furn( fdest ) &&
             !m.veh_at( fdest ) &&

--- a/src/game.h
+++ b/src/game.h
@@ -911,7 +911,9 @@ class game
         /** Check for dangerous stuff at dest_loc, return false if the player decides
         not to step there */
         // Handle pushing during move, returns true if it handled the move
-        bool grabbed_move( const tripoint &dp, bool via_ramp );
+        bool grabbed_move( const tripoint &dp, bool via_ramp, bool stairs_move = false );
+        bool grabbed_veh_move_helper( const tripoint &dp, bool via_ramp, bool stairs_move );
+        bool grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_destination );
         bool grabbed_veh_move( const tripoint &dp );
 
         void control_vehicle(); // Use vehicle controls  '^'

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -107,6 +107,11 @@ bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_
         if( !m.inbounds( target ) || !m.passable( target ) ||
             !m.has_floor_or_support( target ) || m.has_furn( target ) ||
             m.veh_at( target ) || occupied_by_creature ) {
+            // [临时诊断] 定位跨层放置失败的具体检查项，问题定位后移除
+            add_msg( m_info, _( "[vdrag诊断] target=%s dp=%s inbounds=%d passable=%d floor=%d furn=%d veh=%d creature=%d" ),
+                     target.to_string(), dp.to_string(), m.inbounds( target ), m.passable( target ),
+                     m.has_floor_or_support( target ), m.has_furn( target ),
+                     m.veh_at( target ).has_value(), occupied_by_creature );
             add_msg( m_info, _( "跨层通道另一端没有足够空间放下%s。" ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
             return true;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -2,8 +2,11 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <set>
 
 #include "avatar.h"
+#include "creature.h"
+#include "creature_tracker.h"
 #include "debug.h"
 #include "map.h"
 #include "messages.h"
@@ -17,6 +20,115 @@
 #include "vpart_range.h"
 
 static const efftype_id effect_harnessed( "harnessed" );
+
+bool game::grabbed_veh_move_helper( const tripoint &dp, bool via_ramp, bool stairs_move )
+{
+    if( stairs_move ) {
+        return grabbed_veh_move_cross_z( dp, u.pos() );
+    }
+    if( via_ramp && dp.z != 0 ) {
+        return grabbed_veh_move_cross_z( dp, u.pos() + dp );
+    }
+    return grabbed_veh_move( dp );
+}
+
+bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_destination )
+{
+    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos() + u.grab_point );
+    if( !grabbed_vehicle_vp ) {
+        add_msg( m_info, _( "跨层后找不到原先抓住的载具。" ) );
+        u.grab( object_type::NONE );
+        return false;
+    }
+
+    vehicle *grabbed_vehicle = &grabbed_vehicle_vp->vehicle();
+    if( !grabbed_vehicle ||
+        !grabbed_vehicle->handle_potential_theft( get_avatar() ) ) {
+        u.grab( object_type::NONE );
+        return false;
+    }
+
+    const int grabbed_part = grabbed_vehicle_vp->part_index();
+    for( const vpart_reference &vpr : grabbed_vehicle->get_all_parts() ) {
+        monster *mon = grabbed_vehicle->get_monster( vpr.part_index() );
+        if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
+            add_msg( m_info, _( "有动物仍连接在%s上，无法把它拖过跨层通道。" ),
+                     grabbed_vehicle->disp_name() );
+            u.grab( object_type::NONE );
+            return false;
+        }
+    }
+
+    grabbed_vehicle->invalidate_mass();
+    if( dp.z > 0 ) {
+        const int str_req = grabbed_vehicle->total_mass() / 10_kilogram;
+        if( u.get_arm_str() < str_req ) {
+            add_msg( m_bad, _( "你的力量不足以把%s拖到上一层。" ), grabbed_vehicle->disp_name() );
+            u.grab( object_type::NONE );
+            return true;
+        }
+    }
+
+    std::set<tripoint> occupied_tiles;
+    for( const vpart_reference &vpr : grabbed_vehicle->get_all_parts() ) {
+        occupied_tiles.insert( grabbed_vehicle->global_part_pos3( vpr.part_index() ) );
+    }
+    if( occupied_tiles.empty() ) {
+        u.grab( object_type::NONE );
+        return false;
+    }
+
+    const tripoint grabbed_part_pos = grabbed_vehicle->global_part_pos3( grabbed_part );
+    int min_x = occupied_tiles.begin()->x;
+    int max_x = min_x;
+    int min_y = occupied_tiles.begin()->y;
+    int max_y = min_y;
+    for( const tripoint &p : occupied_tiles ) {
+        min_x = std::min( min_x, p.x );
+        max_x = std::max( max_x, p.x );
+        min_y = std::min( min_y, p.y );
+        max_y = std::max( max_y, p.y );
+    }
+
+    const int width = max_x - min_x + 1;
+    const int height = max_y - min_y + 1;
+    const int longest_span = std::max( width, height );
+    if( occupied_tiles.size() > 4 || longest_span > 4 || ( width > 1 && height > 1 ) ) {
+        add_msg( m_info, _( "%s太宽或太长，无法安全通过跨层通道。" ), grabbed_vehicle->disp_name() );
+        u.grab( object_type::NONE );
+        return true;
+    }
+
+    creature_tracker &creatures = get_creature_tracker();
+    for( const tripoint &p : occupied_tiles ) {
+        const tripoint target = p + dp;
+        const bool occupied_by_creature = target == player_destination ||
+                                          creatures.creature_at<Creature>( target ) != nullptr;
+        if( !m.inbounds( target ) || !m.passable( target ) ||
+            !m.has_floor_or_support( target ) || m.has_furn( target ) ||
+            m.veh_at( target ) || occupied_by_creature ) {
+            add_msg( m_info, _( "跨层通道另一端没有足够空间放下%s。" ), grabbed_vehicle->disp_name() );
+            u.grab( object_type::NONE );
+            return true;
+        }
+    }
+
+    m.displace_vehicle( *grabbed_vehicle, dp );
+    m.rebuild_vehicle_level_caches();
+    m.level_vehicle( *grabbed_vehicle );
+    grabbed_vehicle->check_falling_or_floating();
+    if( grabbed_vehicle->is_falling ) {
+        add_msg( m_info, _( "%s开始坠落，你松开了它。" ), grabbed_vehicle->disp_name() );
+        u.grab( object_type::NONE );
+        m.drop_vehicle( dp );
+        return false;
+    }
+
+    const tripoint new_grab_pos = grabbed_part_pos + dp;
+    u.grab( object_type::VEHICLE, new_grab_pos - player_destination );
+    add_msg( _( "你把%s拖过了跨层通道。" ), grabbed_vehicle->disp_name() );
+    return false;
+}
 
 bool game::grabbed_veh_move( const tripoint &dp )
 {

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -109,9 +109,13 @@ bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_
             m.veh_at( target ) || occupied_by_creature ) {
             // [临时诊断] 定位跨层放置失败的具体检查项，问题定位后移除
             add_msg( m_info, _( "[vdrag诊断] target=%s dp=%s inbounds=%d passable=%d floor=%d furn=%d veh=%d creature=%d" ),
-                     target.to_string(), dp.to_string(), m.inbounds( target ), m.passable( target ),
-                     m.has_floor_or_support( target ), m.has_furn( target ),
-                     m.veh_at( target ).has_value(), occupied_by_creature );
+                     target.to_string(), dp.to_string(),
+                     static_cast<int>( m.inbounds( target ) ),
+                     static_cast<int>( m.passable( target ) ),
+                     static_cast<int>( m.has_floor_or_support( target ) ),
+                     static_cast<int>( m.has_furn( target ) ),
+                     static_cast<int>( m.veh_at( target ).has_value() ),
+                     static_cast<int>( occupied_by_creature ) );
             add_msg( m_info, _( "跨层通道另一端没有足够空间放下%s。" ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
             return true;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -71,14 +71,14 @@ bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_
 
     std::set<tripoint> occupied_tiles;
     for( const vpart_reference &vpr : grabbed_vehicle->get_all_parts() ) {
-        occupied_tiles.insert( m.getlocal( grabbed_vehicle->global_part_pos3( vpr.part_index() ) ) );
+        occupied_tiles.insert( grabbed_vehicle->bub_part_pos( vpr.part_index() ).raw() );
     }
     if( occupied_tiles.empty() ) {
         u.grab( object_type::NONE );
         return false;
     }
 
-    const tripoint grabbed_part_pos = m.getlocal( grabbed_vehicle->global_part_pos3( grabbed_part ) );
+    const tripoint grabbed_part_pos = grabbed_vehicle->bub_part_pos( grabbed_part ).raw();
     int min_x = occupied_tiles.begin()->x;
     int max_x = min_x;
     int min_y = occupied_tiles.begin()->y;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -107,22 +107,17 @@ bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_
         if( !m.inbounds( target ) || !m.passable( target ) ||
             !m.has_floor_or_support( target ) || m.has_furn( target ) ||
             m.veh_at( target ) || occupied_by_creature ) {
-            // [临时诊断] 定位跨层放置失败的具体检查项，问题定位后移除
-            add_msg( m_info, _( "[vdrag诊断] target=%s dp=%s inbounds=%d passable=%d floor=%d furn=%d veh=%d creature=%d" ),
-                     target.to_string(), dp.to_string(),
-                     static_cast<int>( m.inbounds( target ) ),
-                     static_cast<int>( m.passable( target ) ),
-                     static_cast<int>( m.has_floor_or_support( target ) ),
-                     static_cast<int>( m.has_furn( target ) ),
-                     static_cast<int>( m.veh_at( target ).has_value() ),
-                     static_cast<int>( occupied_by_creature ) );
             add_msg( m_info, _( "跨层通道另一端没有足够空间放下%s。" ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
             return true;
         }
     }
 
-    m.displace_vehicle( *grabbed_vehicle, dp );
+    if( !m.displace_vehicle( *grabbed_vehicle, dp ) ) {
+        add_msg( m_info, _( "跨层移动%s时发生异常，你松开了它。" ), grabbed_vehicle->disp_name() );
+        u.grab( object_type::NONE );
+        return true;
+    }
     m.rebuild_vehicle_level_caches();
     m.level_vehicle( *grabbed_vehicle );
     grabbed_vehicle->check_falling_or_floating();
@@ -134,6 +129,13 @@ bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_
     }
 
     const tripoint new_grab_pos = grabbed_part_pos + dp;
+    const optional_vpart_position moved_vehicle_vp = m.veh_at( new_grab_pos );
+    if( !moved_vehicle_vp || &moved_vehicle_vp->vehicle() != grabbed_vehicle ) {
+        add_msg( m_info, _( "跨层移动后无法继续抓住%s，你松开了它。" ), grabbed_vehicle->disp_name() );
+        u.grab( object_type::NONE );
+        return false;
+    }
+
     u.grab( object_type::VEHICLE, new_grab_pos - player_destination );
     add_msg( _( "你把%s拖过了跨层通道。" ), grabbed_vehicle->disp_name() );
     return false;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -71,14 +71,14 @@ bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_
 
     std::set<tripoint> occupied_tiles;
     for( const vpart_reference &vpr : grabbed_vehicle->get_all_parts() ) {
-        occupied_tiles.insert( grabbed_vehicle->global_part_pos3( vpr.part_index() ) );
+        occupied_tiles.insert( m.getlocal( grabbed_vehicle->global_part_pos3( vpr.part_index() ) ) );
     }
     if( occupied_tiles.empty() ) {
         u.grab( object_type::NONE );
         return false;
     }
 
-    const tripoint grabbed_part_pos = grabbed_vehicle->global_part_pos3( grabbed_part );
+    const tripoint grabbed_part_pos = m.getlocal( grabbed_vehicle->global_part_pos3( grabbed_part ) );
     int min_x = occupied_tiles.begin()->x;
     int max_x = min_x;
     int min_y = occupied_tiles.begin()->y;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -105,7 +105,7 @@ bool game::grabbed_veh_move_cross_z( const tripoint &dp, const tripoint &player_
         const bool occupied_by_creature = target == player_destination ||
                                           creatures.creature_at<Creature>( target ) != nullptr;
         if( !m.inbounds( target ) || !m.passable( target ) ||
-            !m.has_floor_or_support( target ) || m.has_furn( target ) ||
+            !m.has_floor( target ) || m.has_furn( target ) ||
             m.veh_at( target ) || occupied_by_creature ) {
             add_msg( m_info, _( "跨层通道另一端没有足够空间放下%s。" ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );


### PR DESCRIPTION
## 功能概述

允许玩家**抓取家具和小型载具（如购物车）通过楼梯进行跨层拖拽**：在楼梯口抓取物品后走向楼梯，游戏弹出方向选择界面，确认后物品被搬运到楼梯另一层的落点。

## 使用方法

1. 面向家具或小型载具按抓取键建立抓取
2. 朝楼梯方向移动，触发"是否跨层搬运"询问
3. 选择目标方向（上/下楼及偏移），确认后物品落到楼梯另一端空位
4. 力量不足、载具过宽或落点被占时会给出对应提示

## 完整改动范围（基于基线 2d0add8a 的全分支差异）

| 文件 | 改动 |
|---|---|
| `src/game.h` | 新增 `grabbed_veh_move_cross_z` 声明 |
| `src/game.cpp` | 新增 `grabbed_veh_move_cross_z` 实现（跨层询问、方向选择、落点校验）；`can_move_furniture` 对 `dp.z != 0` 的跨层移动放宽 FLAT/坡道限制，同层行为不变 |
| `src/grab.cpp` | 跨层拖拽入口接入移动流程；占用检查使用 bub 坐标框架（与 map 检查函数一致）；落点使用 `has_floor` 使楼梯格可放置；`displace_vehicle` 失败时安全释放抓取 |

共 3 个文件，+182/−20 行。无 JSON 数据改动；新增玩家可见提示均为源语言中文。

## 关键技术点

- **坐标框架一致性**：载具部件坐标统一经 `bub_part_pos().raw()` 取得，与 `map::passable` 等 plain tripoint 检查函数消费的框架一致（本代码库 `pos_bub()` 直接包装 `global_pos3()`）
- **楼梯落点**：`has_floor_or_support` 会因楼梯允许向下移动而被 valid_move 推断误判为无支撑，改用 `has_floor` 只拒绝真正的开放空气格；家具跨层同理放宽旧 FLAT 检查
- **安全加固**：移动失败时安全释放抓取，移动后重新确认仍是原车才保持抓取

## 分支提交（7 个）

6feadb84 功能实现 → 9527dea4 坐标系初修 → 287586f5/b7b985e9 临时诊断及其编译修复 → e2e86445 收尾清理 → ef32dce8 bub 坐标框架修复 → 31a457ae 楼梯落点修复

## 测试验证

- 运行编号 284（收尾版）：构建成功 — https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32868855667
- 运行编号 286（bub 坐标修复）：构建成功 — https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32920110185
- 运行编号 287（楼梯落点修复，本 PR head）：构建成功 — https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32924069868
- 实机测试（MSVC测试287）：购物车与锁柜可跨层落于楼梯格，脚下格/已占格/开放空气正确拒绝，普通地板跨层与同层拖拽无回归 ✅
