### PR TITLE
修复空中载具生物无限坠落

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10227,13 +10227,11 @@ void map::creature_on_trap( Creature &c, const bool may_avoid ) const
     if( you != nullptr && you->in_vehicle ) {
         return;
     }
-    // 即使并非正式处于车内，只要站在可支撑的载具部件上，
-    // 即表示该生物正立于载具之上，不应触发地形陷阱（例如挂在载具层 t_open_air 地形上的 tr_ledge）。
-    if( you != nullptr ) {
-        if( const std::optional<vpart_reference> vp = veh_at( c.pos() ).part_with_feature(
-                VPFLAG_BOARDABLE, true ) ) {
-            return;
-        }
+    // 即使并非正式处于车内，只要生物站在可支撑的载具部件上，
+    // 就不应触发载具下方地形上的陷阱，例如飞艇所在 t_open_air 上的 tr_ledge。
+    if( const std::optional<vpart_reference> vp = veh_at( c.pos() ).part_with_feature(
+            VPFLAG_BOARDABLE, true ) ) {
+        return;
     }
     maybe_trigger_trap( c.pos(), c, may_avoid );
 }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2015,7 +2015,7 @@ void monster::move()
     nursebot_operate( dragged_foe );
 
     // The monster can sometimes hang in air due to last fall being blocked
-    if( !flies() && here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, pos() ) ) {
+    if( !flies() && !here.has_floor_or_support( pos() ) ) {
         here.creature_on_trap( *this, false );
         if( is_dead() ) {
             return;


### PR DESCRIPTION
## 变更说明

修复空中载具上的生物因仅检查 `TFLAG_NO_FLOOR` 而被重复触发坠落逻辑的问题。

- `src/map.cpp`：载具可支撑部件上的生物不再触发载具下方地形陷阱。
- `src/monmove.cpp`：使用完整的地面或载具支撑判断，避免空中载具上的生物被误判为悬空。

## 完整改动范围

本 PR 相对 `main` 的完整差异仅包含上述 2 个源码文件，无新增玩家可见文本、数据或配方。

## 验证

- Windows & Android Test 运行编号 297：成功
- Windows Tiles x64 MSVC：成功
- Android arm64：成功
- 测试提交：`3d8970540e7caac7d73281b2002883efd55abfbc`
- Actions：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/33050961388
- `git diff --check`：通过