### PR TITLE
让后视镜不再受车辆行驶中的碰撞影响

### DIFF
--- a/data/json/vehicleparts/mirrors.json
+++ b/data/json/vehicleparts/mirrors.json
@@ -20,7 +20,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "100 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "VISION", "PROTRUSION", "UNMOUNT_ON_DAMAGE" ],
+    "flags": [ "VISION", "PROTRUSION", "UNMOUNT_ON_DAMAGE", "NOCOLLIDE" ],
     "breaks_into": [ { "item": "glass_shard", "count": [ 0, 16 ] } ]
   },
   {

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -462804,7 +462804,12 @@ msgstr "%1$s 的 %2$s 被撕破了！"
 #: src/vehicle.cpp:6969 src/vehicle.cpp:6975
 #, c-format
 msgid "The %1$s's %2$s is destroyed!"
-msgstr "%1$s 的 %2$s 被摧毀了！"
+msgstr "%1$s 的 %2$s 被摧毁了！"
+
+#: src/vehicle.cpp:7198 src/vehicle.cpp:7204 src/vehicle.cpp:7234 src/vehicle.cpp:7240 src/vehicle.cpp:7381
+#, c-format
+msgid "The %1$s's %2$s is disconnected!"
+msgstr "%1$s 的 %2$s 脱落了！"
 
 #: src/vehicle.cpp:7220
 #, c-format

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -841,6 +841,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     int impulse = 0;
 
     std::vector<veh_collision> collisions;
+    std::vector<vehicle *> passthrough;
 
     // Find collisions
     // Velocity of car before collision
@@ -879,6 +880,10 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         // Non-vehicle collisions
         for( const veh_collision &coll : collisions ) {
             if( coll.type == veh_coll_veh ) {
+                continue;
+            }
+            if( coll.type == veh_coll_veh_nocollide ) {
+                passthrough.push_back( static_cast<vehicle *>( coll.target ) );
                 continue;
             }
             int part_num = veh.get_non_fake_part( coll.part );
@@ -1027,6 +1032,9 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
                      veh.tow_data.get_towed()->disp_name() );
             veh.tow_data.get_towed()->invalidate_towing( true );
         }
+    }
+    for( vehicle *colveh : passthrough ) {
+        add_vehicle_to_cache( colveh );
     }
     // Redraw scene, but only if the player is not engaged in an activity and
     // the vehicle was seen before or after the move.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -109,6 +109,7 @@ enum veh_coll_type : int {
     veh_coll_veh,      // 2 - vehicle
     veh_coll_bashable, // 3 - bashable
     veh_coll_other,    // 4 - other
+    veh_coll_veh_nocollide, // 5 - vehicle NOCOLLIDE passthrough
     num_veh_coll_types
 };
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -743,6 +743,12 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         if( coll.type == veh_coll_nothing ) {
             continue;
         }
+        if( info.has_flag( "NOCOLLIDE" ) ) {
+            if( coll.type == veh_coll_veh_nocollide ) {
+                here.add_vehicle_to_cache( static_cast<vehicle *>( coll.target ) );
+            }
+            continue;
+        }
 
         colls.push_back( coll );
 
@@ -825,11 +831,25 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     // Disable vehicle/critter collisions when bashing floor
     // TODO: More elegant code
     const bool is_veh_collision = !bash_floor && ovp && &ovp->vehicle() != this;
-    const bool is_body_collision = !bash_floor && critter != nullptr;
 
     veh_collision ret;
     ret.type = veh_coll_nothing;
     ret.part = part;
+
+    // NOCOLLIDE parts are intentionally omitted from movement collisions.
+    // Keep direct damage paths untouched so attacks and explosions can still damage them.
+    if( is_veh_collision ) {
+        const vpart_info &target_info = ovp->vehicle().part_info( ovp->part_index() );
+        if( target_info.has_flag( "NOCOLLIDE" ) ) {
+            ret.type = veh_coll_veh_nocollide;
+            ret.target = &ovp->vehicle();
+            return ret;
+        }
+    } else if( part_info( part ).has_flag( "NOCOLLIDE" ) ) {
+        return ret;
+    }
+
+    const bool is_body_collision = !bash_floor && critter != nullptr;
 
     // Vehicle collisions are a special case. just return the collision.
     // The map takes care of the dynamic stuff.


### PR DESCRIPTION
## 概述

为外后视镜（wing_mirror）引入 NOCOLLIDE 无碰撞语义：车辆行驶时后视镜不再作为移动碰撞体，可穿过灌木、树木、墙体边缘、生物及其他车辆的接触格，不再因一格制碰撞箱频繁损坏，也不会因后视镜先触障而触发整车撞击；同时补齐该部件损毁提示的简体中文翻译。

参考实现：上游 cataclysmbn/Cataclysm-BN#8284（https://github.com/cataclysmbn/Cataclysm-BN/pull/8284 ，提交 a980025b84f3f6cbae59ecc64884722cc9fc95d7，2026-03-07 合并）。微风数据层已定义 NOCOLLIDE 标记但移动碰撞代码尚未消费，本 PR 同时回移 CBN 的车辆接触语义，而非只改 JSON。

## 改动范围（基线 main 26cfde66，分支共 2 个提交）

**8b4f27c7 外后视镜新增NOCOLLIDE并在移动碰撞中穿透处理**
- `data/json/vehicleparts/mirrors.json`：wing_mirror 增加 NOCOLLIDE；耐久 20、damage_modifier 10、UNMOUNT_ON_DAMAGE 均不变
- `src/vehicle.h`：新增 veh_coll_veh_nocollide 碰撞类型
- `src/vehicle_move.cpp`：NOCOLLIDE 部件不产生地形、生物或车辆移动碰撞；若接触的目标车辆部件为 NOCOLLIDE，返回 passthrough 碰撞类型；双方判定均在 part_collision 内完成，直接伤害路径不受影响
- `src/map.cpp`：passthrough 接触不计入车辆撞击与非车辆碰撞伤害；位移后重新登记被穿过车辆的 veh_at 缓存，避免两车擦过后缓存异常

**3bc507be 补齐载具部件脱落消息翻译并修正摧毁消息繁体字**
- `lang/po/zh_CN.po`：新增 "The %1\$s's %2\$s is disconnected!" 译文「%1\$s 的 %2\$s 脱落了！」（覆盖后视镜等 UNMOUNT_ON_DAMAGE 部件及拖车缆绳、电力线路断开提示，共 5 处调用点）；修正 "is destroyed!" 译文繁体字 摧毀→摧毁

## 获取方式与使用方法

- 反光镜为游戏已有车辆部件，无新增配方；适用于所有安装了外后视镜的载具，被动生效，无需操作
- 丧尸直接攻击、枪击、爆炸等直接部件伤害路径保留，后视镜仍可受损，损坏后照旧脱落并掉落为物品

## 验证

- Windows & Android Test 运行编号 311（https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/33236978118 ），分支 fix/wing-mirror-nocollide，head 8b4f27c7，结论 success；MSVC 构件已解压至 D:\Games\CDDA\MSVC测试311-后视镜无碰撞 并完成游戏内六项场景验证（后视镜扫过灌木/丧尸/障碍不再触发撞击、双车仅后视镜交叠后 veh_at 缓存正常、爆炸仍可损坏后视镜、普通部件碰撞无变化）
- 汉化提交 3bc507be 为纯 po 文本变更，未经单独 MSVC 构建，将随后续构建生效