### PR TITLE
修复丧尸主宰宠物默认跟随

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1491,10 +1491,17 @@ bool monster::is_pet() const
 
 bool monster::is_pet_follow() const
 {
-    // Only animals whose original monster faction is the dog faction follow
-    // automatically.  Other tamed animals must be led with a leash.
-    return is_pet() && type->default_faction == monfaction_dog &&
-           !has_flag( MF_PET_WONT_FOLLOW );
+    if( !is_pet() || has_flag( MF_PET_WONT_FOLLOW ) ) {
+        return false;
+    }
+
+    if( type->default_faction == monfaction_dog ) {
+        return true;
+    }
+
+    const Character &player_character = get_player_character();
+    return in_species( species_ZOMBIE ) &&
+           player_character.has_trait( trait_Dominator_Of_Zombies );
 }
 
 bool monster::made_of(phase_id p) const

--- a/src/monster.h
+++ b/src/monster.h
@@ -181,7 +181,7 @@ class monster : public Creature
 
         // Permanent pets are marked by both friendly == -1 and the pet effect.
         bool is_pet() const;
-        // Only dog-type pets follow automatically; other animals require a leash.
+        // Dogs and a zombie dominator's zombie pets follow automatically.
         bool is_pet_follow() const;
 
         bool avoid_trap( const tripoint &pos, const trap &tr ) const override;


### PR DESCRIPTION
## 变更说明
修复丧尸主宰特质拥有者的丧尸宠物不会自动跟随玩家的问题。

## 改动范围
- `src/monster.cpp`：保留犬类宠物自动跟随逻辑，并让拥有 `Dominator_Of_Zombies` 特质的丧尸宠物自动跟随。
- `src/monster.h`：更新 `is_pet_follow()` 注释，准确描述适用对象。

## 验证
- Windows & Android Test 运行编号 315 已成功完成。
- 运行编号 315：`fix/zombie-dominator-pet-follow`，head SHA `dd7b88d1374a72ad011299daf0d6fa86acc54342`。
- 分支相对 `main`（`716621e78b6e19caa4cd70ca2ff71eaccbe09765`）仅领先 1 个提交，包含上述 2 个文件。