### PR TITLE
修复大地图缩放状态不同步并持久化缩放

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -480,7 +480,6 @@ game::game() :
     next_npc_id(1),
     next_mission_id(1),
     remoteveh_cache_time(calendar::before_time_starts),
-    tileset_zoom(DEFAULT_TILESET_ZOOM),
     last_mouse_edge_scroll(std::chrono::steady_clock::now())
 {
     first_redraw_since_waiting_started = true;
@@ -2493,7 +2492,7 @@ std::pair<tripoint, tripoint> game::mouse_edge_scrolling( input_context &ctxt, c
 
 tripoint game::mouse_edge_scrolling_terrain( input_context &ctxt )
 {
-    auto ret = mouse_edge_scrolling( ctxt, std::max( DEFAULT_TILESET_ZOOM / tileset_zoom, 1 ),
+    auto ret = mouse_edge_scrolling( ctxt, std::max( DEFAULT_TILESET_ZOOM / uistate.tileset_zoom, 1 ),
                                      last_mouse_edge_scroll_vector_terrain, g->is_tileset_isometric() );
     last_mouse_edge_scroll_vector_terrain = ret.second;
     last_mouse_edge_scroll_vector_overmap = tripoint_zero;
@@ -3018,6 +3017,9 @@ bool game::load( const save_t &name )
     const JsonValue & jsin ) {
         uistate.deserialize( jsin.get_object() );
     } );
+    // Restore both logical and rendered zoom after loading UI state.
+    set_zoom( uistate.tileset_zoom );
+    set_overmap_zoom( uistate.overmap_tileset_zoom );
     reload_npcs();
     validate_npc_followers();
     validate_mounted_npcs();
@@ -7758,7 +7760,7 @@ look_around_result game::look_around(
     is_looking = true;
     const tripoint prev_offset = u.view_offset;
 
-    const int prev_tileset_zoom = tileset_zoom;
+    const int prev_tileset_zoom = uistate.tileset_zoom;
     while( is_moving_zone && square_dist( start_point, end_point ) > 256 / get_zoom() &&
            get_zoom() != 4 ) {
         zoom_out();
@@ -8104,73 +8106,81 @@ static constexpr int MAXIMUM_ZOOM_LEVEL = 4;
 void game::zoom_out()
 {
 
-    if( tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
-        tileset_zoom = tileset_zoom / 2;
+    if( uistate.tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
+        uistate.tileset_zoom = uistate.tileset_zoom / 2;
     } else {
-        tileset_zoom = 64;
+        uistate.tileset_zoom = 64;
     }
-    rescale_tileset( tileset_zoom );
+    rescale_tileset( uistate.tileset_zoom );
 
 }
 
 void game::zoom_out_overmap()
 {
 
-    if( overmap_tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
-        overmap_tileset_zoom /= 2;
+    if( uistate.overmap_tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
+        uistate.overmap_tileset_zoom /= 2;
     } else {
-        overmap_tileset_zoom = 64;
+        uistate.overmap_tileset_zoom = 64;
     }
-    overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
+    overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
 
 }
 
 void game::zoom_in()
 {
 
-    if( tileset_zoom == 64 ) {
-        tileset_zoom = MAXIMUM_ZOOM_LEVEL;
+    if( uistate.tileset_zoom == 64 ) {
+        uistate.tileset_zoom = MAXIMUM_ZOOM_LEVEL;
     } else {
-        tileset_zoom = tileset_zoom * 2;
+        uistate.tileset_zoom = uistate.tileset_zoom * 2;
     }
-    rescale_tileset( tileset_zoom );
+    rescale_tileset( uistate.tileset_zoom );
 
 }
 
 void game::zoom_in_overmap()
 {
 
-    if( overmap_tileset_zoom == 64 ) {
-        overmap_tileset_zoom = MAXIMUM_ZOOM_LEVEL;
+    if( uistate.overmap_tileset_zoom == 64 ) {
+        uistate.overmap_tileset_zoom = MAXIMUM_ZOOM_LEVEL;
     } else {
-        overmap_tileset_zoom *= 2;
+        uistate.overmap_tileset_zoom *= 2;
     }
-    overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
+    overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
 
 }
 
 void game::reset_zoom()
 {
 
-    tileset_zoom = DEFAULT_TILESET_ZOOM;
-    rescale_tileset( tileset_zoom );
+    uistate.tileset_zoom = DEFAULT_TILESET_ZOOM;
+    rescale_tileset( uistate.tileset_zoom );
 
 }
 
 void game::set_zoom( const int level )
 {
 
-    if( tileset_zoom != level ) {
-        tileset_zoom = level;
-        rescale_tileset( tileset_zoom );
-    }
+    uistate.tileset_zoom = level;
+    // Breeze shares draw dimensions between tile contexts, so always re-apply the scale.
+    rescale_tileset( uistate.tileset_zoom );
+
+}
+
+void game::set_overmap_zoom( const int level )
+{
+
+    uistate.overmap_tileset_zoom = level;
+    // Always re-apply: the normal-map context may have overwritten the shared draw dimensions.
+    overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
 
 }
 
 int game::get_zoom() const
 {
 
-    return tileset_zoom;
+    return uistate.tileset_zoom;
 
 }
 

--- a/src/game.h
+++ b/src/game.h
@@ -81,8 +81,6 @@ class npc_template;
 class spell_events;
 class viewer;
 
-static constexpr int DEFAULT_TILESET_ZOOM = 16;
-
 // The reference to the one and only game instance.
 class game;
 
@@ -728,6 +726,7 @@ class game
         void reenter_fullscreen();
         void zoom_in_overmap();
         void zoom_out_overmap();
+        void set_overmap_zoom( int level );
         void zoom_in();
         void zoom_out();
         void reset_zoom();
@@ -1224,10 +1223,6 @@ class game
 
         // Times the user has input an action
         int user_action_counter = 0; // NOLINT(cata-serialize)
-
-        /** How far the tileset should be zoomed out, 16 is default. 32 is zoomed in by x2, 8 is zoomed out by x0.5 */
-        int tileset_zoom = 0; // NOLINT(cata-serialize)
-        int overmap_tileset_zoom = DEFAULT_TILESET_ZOOM; // NOLINT(cata-serialize)
 
         /** Seed for all the random numbers that should have consistent randomness (weather). */
         unsigned int seed = 0; // NOLINT(cata-serialize)

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -373,6 +373,8 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_debug_weather", overmap_debug_weather );
     json.member( "overmap_visible_weather", overmap_visible_weather );
     json.member( "overmap_debug_mongroup", overmap_debug_mongroup );
+    json.member( "tileset_zoom", tileset_zoom );
+    json.member( "overmap_tileset_zoom", overmap_tileset_zoom );
     json.member( "distraction_noise", distraction_noise );
     json.member( "distraction_pain", distraction_pain );
     json.member( "distraction_attack", distraction_attack );
@@ -442,6 +444,8 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_debug_weather", overmap_debug_weather );
     jo.read( "overmap_visible_weather", overmap_visible_weather );
     jo.read( "overmap_debug_mongroup", overmap_debug_mongroup );
+    jo.read( "tileset_zoom", tileset_zoom );
+    jo.read( "overmap_tileset_zoom", overmap_tileset_zoom );
     jo.read( "distraction_noise", distraction_noise );
     jo.read( "distraction_pain", distraction_pain );
     jo.read( "distraction_attack", distraction_attack );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1741,16 +1741,14 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
     }
 }
 
-static int overmap_zoom_level = DEFAULT_TILESET_ZOOM;
-
 static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                                  const draw_data_t &data = draw_data_t() )
 {
-    const int previous_zoom = g->get_zoom();
-    g->set_zoom( overmap_zoom_level );
+    // Normal map and overmap keep separate logical zoom values.  Because Breeze's
+    // renderer shares draw dimensions, explicitly restore the context being shown.
+    g->set_overmap_zoom( uistate.overmap_tileset_zoom );
     on_out_of_scope reset_zoom( [&]() {
-        overmap_zoom_level = g->get_zoom();
-        g->set_zoom( previous_zoom );
+        g->set_zoom( uistate.tileset_zoom );
         g->mark_main_ui_adaptor_resize();
     } );
 

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -14,6 +14,8 @@
 #include "omdata.h"
 #include "type_id.h"
 
+constexpr int DEFAULT_TILESET_ZOOM = 16;
+
 class item;
 
 struct advanced_inv_pane_save_state {
@@ -132,6 +134,10 @@ class uistatedata
         bool overmap_debug_weather = false;
         // draw monster groups on the overmap.
         bool overmap_debug_mongroup = false;
+
+        // Persist normal-map and overmap zoom independently.
+        int tileset_zoom = DEFAULT_TILESET_ZOOM;
+        int overmap_tileset_zoom = DEFAULT_TILESET_ZOOM;
 
         // Distraction manager stuff
         bool distraction_noise = true;


### PR DESCRIPTION
Fixes #1164

修复大地图重新打开后，显示缩放倍率与内部记录倍率不同步的问题。

原实现中，大地图进入/退出时会临时复用普通地图的缩放状态，而 `z/Z` 实际修改的是另一份大地图缩放状态，因此重新打开大地图后可能出现“画面显示为一个倍率，但第一次缩放却从之前的倍率继续计算”的跳变。

本次修改：

- 将普通地图与大地图的缩放状态分开保存。
- 将两种缩放倍率保存到 `uistate.json`，读档后可以恢复。
- 移除大地图临时复用普通地图缩放倍率的旧机制。
- 进入大地图时重新同步大地图倍率，退出时恢复普通地图倍率。
- 保留原有最大/最小缩放循环行为。

### Testing

- Windows Tiles x64 MSVC 编译通过。
- 实机测试普通地图与大地图使用不同倍率时互不覆盖。
- 测试关闭并重新打开大地图后，显示倍率与 `z/Z` 的实际倍率保持一致。
- 测试保存并重新读档后，两种地图的缩放倍率可以分别恢复。