### PR TITLE
为 Windows 构建加入数据加载烟雾测试

### DIFF
--- a/.github/workflows/msvc-test.yml
+++ b/.github/workflows/msvc-test.yml
@@ -278,6 +278,8 @@ jobs:
             }
           }
 
+      # Upload before the smoke test so developers can still download and inspect
+      # a successfully compiled package even when runtime data validation fails.
       - name: Upload temporary Windows build
         uses: actions/upload-artifact@v4
         with:
@@ -286,6 +288,43 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
+
+      - name: Windows 数据加载烟雾测试
+        shell: pwsh
+        run: |
+          $buildDir = Resolve-Path "windows-test-build"
+          $exe = Join-Path $buildDir "cataclysm-tiles.exe"
+          if( -not ( Test-Path -LiteralPath $exe ) ) {
+            throw "Smoke test executable is missing: $exe"
+          }
+
+          $stdout = Join-Path $env:RUNNER_TEMP "breeze-jsonverify.stdout.log"
+          $stderr = Join-Path $env:RUNNER_TEMP "breeze-jsonverify.stderr.log"
+          $process = Start-Process \
+            -FilePath $exe \
+            -ArgumentList "--jsonverify" \
+            -WorkingDirectory $buildDir \
+            -NoNewWindow \
+            -PassThru \
+            -RedirectStandardOutput $stdout \
+            -RedirectStandardError $stderr
+
+          if( -not $process.WaitForExit(180000) ) {
+            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            throw "cataclysm-tiles.exe --jsonverify did not finish within 180 seconds."
+          }
+
+          $process.Refresh()
+          Write-Host "===== jsonverify stdout ====="
+          if( Test-Path -LiteralPath $stdout ) { Get-Content -LiteralPath $stdout }
+          Write-Host "===== jsonverify stderr ====="
+          if( Test-Path -LiteralPath $stderr ) { Get-Content -LiteralPath $stderr }
+
+          if( $process.ExitCode -ne 0 ) {
+            throw "cataclysm-tiles.exe --jsonverify failed with exit code $($process.ExitCode)."
+          }
+
+          Write-Host "Windows 可执行文件已成功启动并完成核心游戏数据加载验证。"
 
   android:
     name: Android arm64

--- a/.github/workflows/msvc-test.yml
+++ b/.github/workflows/msvc-test.yml
@@ -300,14 +300,7 @@ jobs:
 
           $stdout = Join-Path $env:RUNNER_TEMP "breeze-jsonverify.stdout.log"
           $stderr = Join-Path $env:RUNNER_TEMP "breeze-jsonverify.stderr.log"
-          $process = Start-Process \
-            -FilePath $exe \
-            -ArgumentList "--jsonverify" \
-            -WorkingDirectory $buildDir \
-            -NoNewWindow \
-            -PassThru \
-            -RedirectStandardOutput $stdout \
-            -RedirectStandardError $stderr
+          $process = Start-Process -FilePath $exe -ArgumentList "--jsonverify" -WorkingDirectory $buildDir -NoNewWindow -PassThru -RedirectStandardOutput $stdout -RedirectStandardError $stderr
 
           if( -not $process.WaitForExit(180000) ) {
             Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -70,11 +70,23 @@ jobs:
 
             const recommended = ['快速检查'];
             if (has('src/') || has('msvc-full-features/') || has('data/') || has('tools/') || has('build-scripts/')) {
-              recommended.push('Windows Tiles x64 MSVC');
+              recommended.push('Windows Tiles x64 MSVC', 'Windows 数据加载烟雾测试');
             }
             if (has('src/') || has('android/') || has('data/') || has('gfx/')) {
               recommended.push('Android Gradle 快速检查', 'Android arm64');
             }
+
+            const uniqueRecommended = [...new Set(recommended)];
+            const testDetails = {
+              '快速检查': '检查补丁空白、变更 JSON/Python/XML/Visual Studio 项目文件、未解决合并标记，以及内置穆尔卡武器工坊关键路径。',
+              'Windows Tiles x64 MSVC': '编译翻译，执行完整 Release x64 MSVC 构建和 windist 打包，并验证 Windows 构件中的内置武器工坊。',
+              'Windows 数据加载烟雾测试': '运行打包后的 cataclysm-tiles.exe --jsonverify，确认可执行文件能够真正启动并完成核心游戏数据加载；Windows 构件会先上传，烟雾测试失败时仍可下载人工排查。',
+              'Android Gradle 快速检查': '使用 JDK 11 解析 Gradle 配置和依赖，提前发现 Android 构建环境或脚本问题。',
+              'Android arm64': '编译翻译和 arm64 Release APK，并保留 APK 构件供设备实测。',
+            };
+            const testText = uniqueRecommended
+              .map((test) => `- **${test}：** ${testDetails[test]}`)
+              .join('\n');
 
             const riskText = risks.length > 0
               ? risks.map((risk) => `- ⚠️ ${risk}`).join('\n')
@@ -90,7 +102,8 @@ jobs:
             **自动风险提示：**
             ${riskText}
 
-            **建议至少通过：** ${[...new Set(recommended)].join('、')}
+            **建议测试内容：**
+            ${testText}
 
             这是免费的规则型自动审查，只负责快速发现范围、平台和集成风险，不替代人工代码审查。后续如果我们批量同步上游 PR，它会在每次推送后自动刷新这条摘要。`;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -339,7 +339,7 @@ int main( int argc, const char *argv[] )
     method_id_isHardwareKeyboardAvailable = jni_env->GetMethodID(j_class, "isHardwareKeyboardAvailable", "()Z");
     method_id_vibrate = jni_env->GetMethodID(j_class, "vibrate", "(I)V");
     method_id_show_sdl_surface = jni_env->GetMethodID(j_class, "show_sdl_surface", "()V");
-    method_id_toast = jni_env->GetMethodID(j_class,"toast","(Ljava/lang/String;Z)V");
+    method_id_toast = jni_env->GetMethodID(j_class,"toast","(Ljava/lang/String;)V");
     method_id_showToastMessage = jni_env->GetMethodID(j_class, "showToastMessage", "(Ljava/lang/String;)V");
     method_id_getDefaultSetting = jni_env->GetMethodID(j_class, "getDefaultSetting", "(Ljava/lang/String;Z)Z");
     method_id_getSystemLang = jni_env->GetMethodID(j_class, "getSystemLang", "()Ljava/lang/String;");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -263,6 +263,10 @@ int main( int argc, const char *argv[] )
 
     MAP_SHARING::setDefaults();
 
+    // Breeze currently keeps the legacy command-line documentation but no longer runs the
+    // original parser.  Keep --jsonverify working because CI and developers rely on it.
+    const bool json_verify = std::count( argv, argv + argc, std::string( "--jsonverify" ) ) > 0;
+
     if( !dir_exist( PATH_INFO::datadir() ) ) {
         printf( "Fatal: Can't find data directory \"%s\"\nPlease ensure the current working directory is correct or specify data directory with --datadir.  Perhaps you meant to start \"cataclysm-launcher\"?\n",
                 PATH_INFO::datadir().c_str() );
@@ -335,7 +339,7 @@ int main( int argc, const char *argv[] )
     method_id_isHardwareKeyboardAvailable = jni_env->GetMethodID(j_class, "isHardwareKeyboardAvailable", "()Z");
     method_id_vibrate = jni_env->GetMethodID(j_class, "vibrate", "(I)V");
     method_id_show_sdl_surface = jni_env->GetMethodID(j_class, "show_sdl_surface", "()V");
-    method_id_toast = jni_env->GetMethodID(j_class,"toast","(Ljava/lang/String;)V");
+    method_id_toast = jni_env->GetMethodID(j_class,"toast","(Ljava/lang/String;Z)V");
     method_id_showToastMessage = jni_env->GetMethodID(j_class, "showToastMessage", "(Ljava/lang/String;)V");
     method_id_getDefaultSetting = jni_env->GetMethodID(j_class, "getDefaultSetting", "(Ljava/lang/String;Z)Z");
     method_id_getSystemLang = jni_env->GetMethodID(j_class, "getSystemLang", "()Ljava/lang/String;");
@@ -370,6 +374,9 @@ int main( int argc, const char *argv[] )
     // depend on the mods.
     try {
         g->load_static_data();
+        if( json_verify ) {
+            exit_handler( 0 );
+        }
     } catch( const std::exception &err ) {
         debugmsg( "%s", err.what() );
         exit_handler( -999 );


### PR DESCRIPTION
## 说明
继续完善微风 PR 的自动验证流程。在保留 Windows/Android 完整编译和开发者可下载测试构件的基础上，让 Windows CI 在打包完成后实际启动 `cataclysm-tiles.exe` 并执行 `--jsonverify`，验证核心游戏数据能够被运行时加载，而不仅仅是“可以编译”。

## 主要改动
- Windows 完整 MSVC 构建和 windist 打包后，先上传原有 Windows 测试构件，仍保留 7 天供开发者下载实测。
- 新增“Windows 数据加载烟雾测试”，运行打包后的 `cataclysm-tiles.exe --jsonverify`。
- Windows 构件在烟雾测试之前上传，因此即使运行时数据验证失败，开发者仍可下载成功编译的版本复现和排查。
- 扩充“微风 PR 自动审查”的评论内容，不再只列测试名称，而是解释快速检查、Windows 编译、Windows 数据加载烟雾测试、Android Gradle 检查和 Android arm64 各自在测试什么。

## 首轮测试发现与修复
首轮 CI 中 Windows/Android 编译均成功，Windows 测试构件也正常上传，但 `cataclysm-tiles.exe --jsonverify` 运行 180 秒后没有退出。排查发现这不是数据加载本身卡死，而是微风当前 `src/main.cpp` 虽然还保留旧命令行参数相关结构和文档，但已经没有执行原来的命令行解析流程，因此 `--jsonverify` 实际被忽略，程序照常进入主菜单并持续运行。

本 PR 现在补回一个最小、专用的 `--jsonverify` 契约：检测到该参数时正常初始化程序并加载核心静态数据，加载成功后立即正常退出。这里没有恢复整套旧命令行解析器，避免为了 CI 引入与烟雾测试无关的大范围代码。

## 安全与性能
不增加第三方服务，不需要额外密钥。烟雾测试只运行本仓库自己刚刚编译出的 Windows 构件。正常情况下仅增加一次核心静态数据加载；不会创建世界、运行游戏回合或执行长期测试。

## 验证目标
本 PR 自己应通过快速检查、Windows Tiles x64 MSVC、Windows 数据加载烟雾测试、Android Gradle 快速检查和 Android arm64。机器人更新后的详细说明会在本 PR 合并后的后续 PR 中生效。